### PR TITLE
Serde implementation for ternary types

### DIFF
--- a/bee-ternary/Cargo.toml
+++ b/bee-ternary/Cargo.toml
@@ -6,12 +6,14 @@ edition = "2018"
 
 [dependencies]
 bee-common = { path = "../bee-common" }
-
-#lazy_static = "1.4.0"
-#failure = "0.1.6"
+serde = { version = "1.0", optional = true }
 
 # ONLY TEMPORARY
 iota-conversion = { path = "../iota-conversion" }
 
 #[dev-dependencies]
 rand = "0.7"
+serde_json = "1.0"
+
+[features]
+serde1 = ["serde"]

--- a/bee-ternary/src/lib.rs
+++ b/bee-ternary/src/lib.rs
@@ -7,6 +7,9 @@ pub mod t3b1;
 pub mod t4b1;
 pub mod util;
 
+#[cfg(feature = "serde1")]
+mod serde;
+
 use std::{
     ops::{Deref, DerefMut, Range, Index, IndexMut},
     cmp::PartialEq,

--- a/bee-ternary/src/serde.rs
+++ b/bee-ternary/src/serde.rs
@@ -1,0 +1,121 @@
+use std::{
+    fmt,
+    convert::TryFrom,
+    marker::PhantomData,
+};
+use serde::{
+    Serialize,
+    Serializer,
+    ser::SerializeSeq,
+    Deserialize,
+    Deserializer,
+    de::{Visitor, SeqAccess, Error, Unexpected},
+};
+use crate::{
+    Trit,
+    Trits,
+    TritBuf,
+    RawEncoding,
+    RawEncodingBuf,
+};
+
+// Serialisation
+
+impl Serialize for Trit {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_i8((*self).into())
+    }
+}
+
+impl<'a, T: RawEncoding> Serialize for &'a Trits<T> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(self.len()))?;
+        for trit in self.iter() {
+            seq.serialize_element(&trit)?;
+        }
+        seq.end()
+    }
+}
+
+impl<T: RawEncodingBuf> Serialize for TritBuf<T> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(self.len()))?;
+        for trit in self.iter() {
+            seq.serialize_element(&trit)?;
+        }
+        seq.end()
+    }
+}
+
+// Deserialisation
+
+struct TritVisitor;
+
+impl<'de> Visitor<'de> for TritVisitor {
+    type Value = Trit;
+
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("a value between -1 and 1 inclusive")
+    }
+
+    fn visit_u64<E: Error>(self, trit: u64) -> Result<Self::Value, E> {
+        i8::try_from(trit)
+            .map_err(|_| ())
+            .and_then(|trit| Trit::try_from(trit)
+                .map_err(|_| ()))
+            .map_err(|_| E::invalid_value(Unexpected::Unsigned(trit), &self))
+    }
+
+    fn visit_i64<E: Error>(self, trit: i64) -> Result<Self::Value, E> {
+        i8::try_from(trit)
+            .map_err(|_| ())
+            .and_then(|trit| Trit::try_from(trit)
+                .map_err(|_| ()))
+            .map_err(|_| E::invalid_value(Unexpected::Signed(trit), &self))
+    }
+
+    fn visit_u8<E: Error>(self, trit: u8) -> Result<Self::Value, E> {
+        i8::try_from(trit)
+            .map_err(|_| ())
+            .and_then(|trit| Trit::try_from(trit)
+                .map_err(|_| ()))
+            .map_err(|_| E::invalid_value(Unexpected::Unsigned(trit as u64), &self))
+    }
+
+    fn visit_i8<E: Error>(self, trit: i8) -> Result<Self::Value, E> {
+        Trit::try_from(trit)
+            .map_err(|_| E::invalid_value(Unexpected::Signed(trit as i64), &self))
+    }
+}
+
+impl<'de> Deserialize<'de> for Trit {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_i8(TritVisitor)
+    }
+}
+
+struct TritBufVisitor<T>(PhantomData<T>);
+
+impl<'de, T: RawEncodingBuf> Visitor<'de> for TritBufVisitor<T> {
+    type Value = TritBuf<T>;
+
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("a sequence of trits")
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+        let mut buf = TritBuf::with_capacity(seq.size_hint().unwrap_or(0));
+
+        while let Some(trit) = seq.next_element()? {
+            buf.push(trit);
+        }
+
+        Ok(buf)
+    }
+}
+
+impl<'de, T: RawEncodingBuf> Deserialize<'de> for TritBuf<T> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_seq(TritBufVisitor::<T>(PhantomData))
+    }
+}

--- a/bee-ternary/src/trit.rs
+++ b/bee-ternary/src/trit.rs
@@ -10,12 +10,8 @@ pub enum Trit {
 
 impl From<i8> for Trit {
     fn from(x: i8) -> Self {
-        match x {
-            -1 => Trit::MinusOne,
-            0 => Trit::Zero,
-            1 => Trit::PlusOne,
-            x => panic!("Invalid trit representation '{}'", x),
-        }
+        Self::try_from(x)
+            .unwrap_or_else(|_| panic!("Invalid trit representation '{}'", x))
     }
 }
 
@@ -40,6 +36,16 @@ impl Into<i8> for Trit {
 }
 
 impl Trit {
+    // TODO: Use std::convert::TryFrom
+    pub fn try_from(x: i8) -> Result<Self, ()> {
+        match x {
+            -1 => Ok(Trit::MinusOne),
+            0 => Ok(Trit::Zero),
+            1 => Ok(Trit::PlusOne),
+            x => Err(()),
+        }
+    }
+
     pub fn checked_increment(self) -> Option<Self> {
         match self {
             Trit::MinusOne => Some(Trit::Zero),

--- a/bee-ternary/tests/serde.rs
+++ b/bee-ternary/tests/serde.rs
@@ -1,0 +1,50 @@
+#![cfg(feature = "serde1")]
+
+use std::ops::Range;
+use rand::prelude::*;
+use bee_ternary::*;
+
+fn gen_buf<T: raw::RawEncodingBuf>(len: Range<usize>) -> (TritBuf<T>, Vec<i8>) {
+    let len = thread_rng().gen_range(len.start, len.end);
+    let trits = (0..len)
+        .map(|_| (thread_rng().gen::<u8>() % 3) as i8 - 1)
+        .collect::<Vec<_>>();
+    (TritBuf::<T>::from_i8_unchecked(&trits), trits)
+}
+
+// Not exactly fuzzing, just doing something a lot
+fn fuzz(n: usize, mut f: impl FnMut()) {
+    (0..n).for_each(|_| f());
+}
+
+fn serialize_generic<T: raw::RawEncodingBuf>() {
+    let (a, a_i8) = gen_buf::<T>(0..1000);
+    assert_eq!(
+        serde_json::to_string(&a).unwrap(),
+        format!("[{}]", a_i8.iter().map(|t| t.to_string()).collect::<Vec<_>>().join(",")),
+    );
+}
+
+fn deserialize_generic<T: raw::RawEncodingBuf>() {
+    let (a, a_i8) = gen_buf::<T>(0..1000);
+    assert_eq!(
+        serde_json::from_str::<TritBuf<T>>(&format!("[{}]", a_i8.iter().map(|t| t.to_string()).collect::<Vec<_>>().join(","))).unwrap(),
+        a,
+    );
+}
+
+#[test]
+fn serialize() {
+    serialize_generic::<T1B1Buf>();
+    serialize_generic::<T2B1Buf>();
+    serialize_generic::<T3B1Buf>();
+    serialize_generic::<T4B1Buf>();
+}
+
+#[test]
+fn deserialize() {
+    deserialize_generic::<T1B1Buf>();
+    deserialize_generic::<T2B1Buf>();
+    deserialize_generic::<T3B1Buf>();
+    deserialize_generic::<T4B1Buf>();
+}


### PR DESCRIPTION
Serde is supported by enabling the `serde1` feature of `bee-ternary`. Tests for all encodings included.