### PR TITLE
New trit encoding for Transaction types

### DIFF
--- a/bee-bundle/Cargo.toml
+++ b/bee-bundle/Cargo.toml
@@ -9,4 +9,5 @@ bee-common = { path = "../bee-common" }
 bee-crypto = { path = "../bee-crypto" }
 bee-pow = { path = "../bee-pow" }
 bee-signing = { path = "../bee-signing" }
-bee-ternary = { path = "../bee-ternary" }
+bee-ternary = { path = "../bee-ternary", features = ["serde1"] }
+serde = { version = "1.0", features = ["derive"] }

--- a/bee-bundle/src/bundle.rs
+++ b/bee-bundle/src/bundle.rs
@@ -103,7 +103,7 @@ where
     // TODO TEST
     pub fn new() -> Self {
         Self {
-            transactions: Transactions::default(),
+            transactions: Transactions::new(),
             essence_sponge: PhantomData,
             public_key: PhantomData,
             stage: PhantomData,

--- a/bee-bundle/src/lib.rs
+++ b/bee-bundle/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate serde;
+
 mod bundle;
 mod constants;
 mod transaction;

--- a/bee-bundle/src/transaction.rs
+++ b/bee-bundle/src/transaction.rs
@@ -26,6 +26,10 @@ impl Payload {
 
         Self(tritbuf)
     }
+
+    pub fn as_bytes(&self) -> &[i8] {
+        self.0.as_i8_slice()
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -45,6 +49,10 @@ impl Address {
         let tritbuf = trytes_to_trits_buf(&address);
 
         Self(tritbuf)
+    }
+
+    pub fn as_bytes(&self) -> &[i8] {
+        self.0.as_i8_slice()
     }
 }
 
@@ -68,6 +76,10 @@ impl Tag {
         let tritbuf = trytes_to_trits_buf(&tag);
 
         Self(tritbuf)
+    }
+
+    pub fn as_bytes(&self) -> &[i8] {
+        self.0.as_i8_slice()
     }
 }
 
@@ -95,6 +107,10 @@ impl Hash {
 
         Self(tritbuf)
     }
+
+    pub fn as_bytes(&self) -> &[i8] {
+        self.0.as_i8_slice()
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -114,6 +130,10 @@ impl Nonce {
         let tritbuf = trytes_to_trits_buf(&nonce);
 
         Self(tritbuf)
+    }
+
+    pub fn as_bytes(&self) -> &[i8] {
+        self.0.as_i8_slice()
     }
 }
 

--- a/bee-bundle/src/transaction.rs
+++ b/bee-bundle/src/transaction.rs
@@ -49,7 +49,7 @@ macro_rules! implement_eq {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Payload<T: RawEncodingBuf = T1B1Buf>(TritBuf<T>);
 
 impl Payload {
@@ -69,7 +69,7 @@ impl Payload {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Address<T: RawEncodingBuf = T1B1Buf>(TritBuf<T>);
 
 // TODO Hash
@@ -94,7 +94,7 @@ impl Address {
 #[derive(Debug, Clone)]
 pub struct Value(pub i64);
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Tag<T: RawEncodingBuf = T1B1Buf>(TritBuf<T>);
 
 impl Tag {
@@ -120,7 +120,7 @@ pub struct Timestamp(pub u64);
 #[derive(Debug, Clone)]
 pub struct Index(pub usize);
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Hash<T: RawEncodingBuf = T1B1Buf>(TritBuf<T>);
 
 // TODO Hash
@@ -142,7 +142,7 @@ impl Hash {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Nonce<T: RawEncodingBuf = T1B1Buf>(TritBuf<T>);
 
 impl Nonce {

--- a/bee-bundle/src/transaction.rs
+++ b/bee-bundle/src/transaction.rs
@@ -272,11 +272,12 @@ impl fmt::Debug for Transaction {
     }
 }
 
+#[derive(Default)]
 pub struct Transactions(pub(crate) Vec<Transaction>);
 
 impl Transactions {
     pub fn new() -> Self {
-        Self(Vec::new())
+        Self::default()
     }
 
     pub fn get(&self, index: usize) -> Option<&Transaction> {

--- a/bee-bundle/src/transaction.rs
+++ b/bee-bundle/src/transaction.rs
@@ -1,8 +1,6 @@
-use crate::constants::{IOTA_SUPPLY, PAYLOAD, ADDRESS, TAG, BUNDLE_HASH, NONCE};
+use crate::constants::{ADDRESS, BUNDLE_HASH, IOTA_SUPPLY, NONCE, PAYLOAD, TAG};
 
-use bee_common::constants::{
-    TRANSACTION_TRYT_LEN, TRYTE_ZERO
-};
+use bee_common::constants::{TRANSACTION_TRYT_LEN, TRYTE_ZERO};
 use bee_common::Errors;
 use bee_common::Result as BeeResult;
 use bee_ternary::{raw::RawEncodingBuf, util::trytes_to_trits_buf, IsTryte, T1B1Buf, TritBuf};

--- a/bee-bundle/src/transaction.rs
+++ b/bee-bundle/src/transaction.rs
@@ -1,7 +1,6 @@
-use crate::constants::IOTA_SUPPLY;
+use crate::constants::{IOTA_SUPPLY, PAYLOAD, ADDRESS, TAG, BUNDLE_HASH, NONCE};
 
 use bee_common::constants::{
-    ADDRESS_TRIT_LEN, HASH_TRIT_LEN, NONCE_TRIT_LEN, PAYLOAD_TRIT_LEN, TAG_TRIT_LEN,
     TRANSACTION_TRYT_LEN,
 };
 use bee_common::Errors;
@@ -54,14 +53,14 @@ pub struct Payload<T: RawEncodingBuf = T1B1Buf>(TritBuf<T>);
 
 impl Payload {
     pub fn zeros() -> Self {
-        Self(TritBuf::zeros(PAYLOAD_TRIT_LEN))
+        Self(TritBuf::zeros(PAYLOAD.trit_offset.length))
     }
 
     pub fn from_str(payload: &str) -> Self {
-        assert!(payload.len() <= PAYLOAD_TRIT_LEN / 3);
+        assert!(payload.len() <= PAYLOAD.tryte_offset.length);
         assert!(payload.chars().all(|c| c.is_tryte()));
 
-        let missing_trytes = PAYLOAD_TRIT_LEN / 3 - payload.len();
+        let missing_trytes = PAYLOAD.tryte_offset.length - payload.len();
         let payload = payload.to_owned() + &"9".repeat(missing_trytes);
         let tritbuf = trytes_to_trits_buf(&payload);
 
@@ -76,14 +75,14 @@ pub struct Address<T: RawEncodingBuf = T1B1Buf>(TritBuf<T>);
 
 impl Address {
     pub fn zeros() -> Self {
-        Self(TritBuf::zeros(ADDRESS_TRIT_LEN))
+        Self(TritBuf::zeros(ADDRESS.trit_offset.length))
     }
 
     pub fn from_str(address: &str) -> Self {
-        assert!(address.len() <= ADDRESS_TRIT_LEN / 3);
+        assert!(address.len() <= ADDRESS.tryte_offset.length);
         assert!(address.chars().all(|c| c.is_tryte()));
 
-        let missing_trytes = ADDRESS_TRIT_LEN / 3 - address.len();
+        let missing_trytes = ADDRESS.tryte_offset.length - address.len();
         let address = address.to_owned() + &"9".repeat(missing_trytes);
         let tritbuf = trytes_to_trits_buf(&address);
 
@@ -99,14 +98,14 @@ pub struct Tag<T: RawEncodingBuf = T1B1Buf>(TritBuf<T>);
 
 impl Tag {
     pub fn zeros() -> Self {
-        Self(TritBuf::zeros(TAG_TRIT_LEN))
+        Self(TritBuf::zeros(TAG.trit_offset.length))
     }
 
     pub fn from_str(tag: &str) -> Self {
-        assert!(tag.len() <= TAG_TRIT_LEN / 3);
+        assert!(tag.len() <= TAG.tryte_offset.length);
         assert!(tag.chars().all(|c| c.is_tryte()));
 
-        let missing_trytes = TAG_TRIT_LEN / 3 - tag.len();
+        let missing_trytes = TAG.tryte_offset.length - tag.len();
         let tag = tag.to_owned() + &"9".repeat(missing_trytes);
         let tritbuf = trytes_to_trits_buf(&tag);
 
@@ -127,14 +126,14 @@ pub struct Hash<T: RawEncodingBuf = T1B1Buf>(TritBuf<T>);
 
 impl Hash {
     pub fn zeros() -> Self {
-        Self(TritBuf::zeros(HASH_TRIT_LEN))
+        Self(TritBuf::zeros(BUNDLE_HASH.trit_offset.length))
     }
 
     pub fn from_str(hash: &str) -> Self {
-        assert!(hash.len() <= HASH_TRIT_LEN / 3);
+        assert!(hash.len() <= BUNDLE_HASH.tryte_offset.length);
         assert!(hash.chars().all(|c| c.is_tryte()));
 
-        let missing_trytes = HASH_TRIT_LEN / 3 - hash.len();
+        let missing_trytes = BUNDLE_HASH.tryte_offset.length - hash.len();
         let hash = hash.to_owned() + &"9".repeat(missing_trytes);
         let tritbuf = trytes_to_trits_buf(&hash);
 
@@ -147,14 +146,14 @@ pub struct Nonce<T: RawEncodingBuf = T1B1Buf>(TritBuf<T>);
 
 impl Nonce {
     pub fn zeros() -> Self {
-        Self(TritBuf::zeros(NONCE_TRIT_LEN))
+        Self(TritBuf::zeros(NONCE.trit_offset.length))
     }
 
     pub fn from_str(nonce: &str) -> Self {
-        assert!(nonce.len() <= NONCE_TRIT_LEN / 3);
+        assert!(nonce.len() <= NONCE.tryte_offset.length);
         assert!(nonce.chars().all(|c| c.is_tryte()));
 
-        let missing_trytes = NONCE_TRIT_LEN / 3 - nonce.len();
+        let missing_trytes = NONCE.tryte_offset.length - nonce.len();
         let nonce = nonce.to_owned() + &"9".repeat(missing_trytes);
         let tritbuf = trytes_to_trits_buf(&nonce);
 

--- a/bee-bundle/src/transaction.rs
+++ b/bee-bundle/src/transaction.rs
@@ -6,6 +6,7 @@ use bee_common::Result as BeeResult;
 use bee_ternary::{util::trytes_to_trits_buf, IsTryte, T1B1Buf, TritBuf};
 
 use std::fmt;
+use std::iter;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Payload(TritBuf<T1B1Buf>);
@@ -20,7 +21,7 @@ impl Payload {
         assert!(payload.chars().all(|c| c.is_tryte()));
 
         let missing_trytes = PAYLOAD.tryte_offset.length - payload.len();
-        let payload = payload.to_owned() + &TRYTE_ZERO.to_string().repeat(missing_trytes);
+        let payload = payload.to_owned() + &iter::repeat(TRYTE_ZERO).take(missing_trytes).collect::<String>();
         let tritbuf = trytes_to_trits_buf(&payload);
 
         Self(tritbuf)
@@ -40,7 +41,7 @@ impl Address {
         assert!(address.chars().all(|c| c.is_tryte()));
 
         let missing_trytes = ADDRESS.tryte_offset.length - address.len();
-        let address = address.to_owned() + &TRYTE_ZERO.to_string().repeat(missing_trytes);
+        let address = address.to_owned() + &iter::repeat(TRYTE_ZERO).take(missing_trytes).collect::<String>();
         let tritbuf = trytes_to_trits_buf(&address);
 
         Self(tritbuf)
@@ -63,7 +64,7 @@ impl Tag {
         assert!(tag.chars().all(|c| c.is_tryte()));
 
         let missing_trytes = TAG.tryte_offset.length - tag.len();
-        let tag = tag.to_owned() + &TRYTE_ZERO.to_string().repeat(missing_trytes);
+        let tag = tag.to_owned() + &iter::repeat(TRYTE_ZERO).take(missing_trytes).collect::<String>();
         let tritbuf = trytes_to_trits_buf(&tag);
 
         Self(tritbuf)
@@ -89,7 +90,7 @@ impl Hash {
         assert!(hash.chars().all(|c| c.is_tryte()));
 
         let missing_trytes = BUNDLE_HASH.tryte_offset.length - hash.len();
-        let hash = hash.to_owned() + &TRYTE_ZERO.to_string().repeat(missing_trytes);
+        let hash = hash.to_owned() + &iter::repeat(TRYTE_ZERO).take(missing_trytes).collect::<String>();
         let tritbuf = trytes_to_trits_buf(&hash);
 
         Self(tritbuf)
@@ -109,7 +110,7 @@ impl Nonce {
         assert!(nonce.chars().all(|c| c.is_tryte()));
 
         let missing_trytes = NONCE.tryte_offset.length - nonce.len();
-        let nonce = nonce.to_owned() + &TRYTE_ZERO.to_string().repeat(missing_trytes);
+        let nonce = nonce.to_owned() + &iter::repeat(TRYTE_ZERO).take(missing_trytes).collect::<String>();
         let tritbuf = trytes_to_trits_buf(&nonce);
 
         Self(tritbuf)

--- a/bee-bundle/src/transaction.rs
+++ b/bee-bundle/src/transaction.rs
@@ -30,8 +30,6 @@ impl Payload {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Address(TritBuf<T1B1Buf>);
 
-// TODO Hash
-
 impl Address {
     pub fn zeros() -> Self {
         Self(TritBuf::zeros(ADDRESS.trit_offset.length))
@@ -80,8 +78,6 @@ pub struct Index(pub usize);
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Hash(TritBuf<T1B1Buf>);
-
-// TODO Hash
 
 impl Hash {
     pub fn zeros() -> Self {

--- a/bee-bundle/src/transaction.rs
+++ b/bee-bundle/src/transaction.rs
@@ -300,6 +300,7 @@ pub enum TransactionBuilderError {
     InvalidValue(i64),
 }
 
+#[derive(Default)]
 pub struct TransactionBuilder {
     pub(crate) payload: Option<Payload>,
     pub(crate) address: Option<Address>,
@@ -320,23 +321,7 @@ pub struct TransactionBuilder {
 
 impl TransactionBuilder {
     pub fn new() -> Self {
-        Self {
-            payload: None,
-            address: None,
-            value: None,
-            obsolete_tag: None,
-            timestamp: None,
-            index: None,
-            last_index: None,
-            bundle: None,
-            trunk: None,
-            branch: None,
-            tag: None,
-            attachment_ts: None,
-            attachment_lbts: None,
-            attachment_ubts: None,
-            nonce: None,
-        }
+        Self::default()
     }
 
     pub fn with_payload(mut self, payload: Payload) -> Self {

--- a/bee-bundle/src/transaction.rs
+++ b/bee-bundle/src/transaction.rs
@@ -1,7 +1,7 @@
 use crate::constants::{IOTA_SUPPLY, PAYLOAD, ADDRESS, TAG, BUNDLE_HASH, NONCE};
 
 use bee_common::constants::{
-    TRANSACTION_TRYT_LEN,
+    TRANSACTION_TRYT_LEN, TRYTE_ZERO
 };
 use bee_common::Errors;
 use bee_common::Result as BeeResult;
@@ -61,7 +61,7 @@ impl Payload {
         assert!(payload.chars().all(|c| c.is_tryte()));
 
         let missing_trytes = PAYLOAD.tryte_offset.length - payload.len();
-        let payload = payload.to_owned() + &"9".repeat(missing_trytes);
+        let payload = payload.to_owned() + &TRYTE_ZERO.to_string().repeat(missing_trytes);
         let tritbuf = trytes_to_trits_buf(&payload);
 
         Self(tritbuf)
@@ -83,7 +83,7 @@ impl Address {
         assert!(address.chars().all(|c| c.is_tryte()));
 
         let missing_trytes = ADDRESS.tryte_offset.length - address.len();
-        let address = address.to_owned() + &"9".repeat(missing_trytes);
+        let address = address.to_owned() + &TRYTE_ZERO.to_string().repeat(missing_trytes);
         let tritbuf = trytes_to_trits_buf(&address);
 
         Self(tritbuf)
@@ -106,7 +106,7 @@ impl Tag {
         assert!(tag.chars().all(|c| c.is_tryte()));
 
         let missing_trytes = TAG.tryte_offset.length - tag.len();
-        let tag = tag.to_owned() + &"9".repeat(missing_trytes);
+        let tag = tag.to_owned() + &TRYTE_ZERO.to_string().repeat(missing_trytes);
         let tritbuf = trytes_to_trits_buf(&tag);
 
         Self(tritbuf)
@@ -134,7 +134,7 @@ impl Hash {
         assert!(hash.chars().all(|c| c.is_tryte()));
 
         let missing_trytes = BUNDLE_HASH.tryte_offset.length - hash.len();
-        let hash = hash.to_owned() + &"9".repeat(missing_trytes);
+        let hash = hash.to_owned() + &TRYTE_ZERO.to_string().repeat(missing_trytes);
         let tritbuf = trytes_to_trits_buf(&hash);
 
         Self(tritbuf)
@@ -154,7 +154,7 @@ impl Nonce {
         assert!(nonce.chars().all(|c| c.is_tryte()));
 
         let missing_trytes = NONCE.tryte_offset.length - nonce.len();
-        let nonce = nonce.to_owned() + &"9".repeat(missing_trytes);
+        let nonce = nonce.to_owned() + &TRYTE_ZERO.to_string().repeat(missing_trytes);
         let tritbuf = trytes_to_trits_buf(&nonce);
 
         Self(tritbuf)


### PR DESCRIPTION
Refactor all types of transaction fields and transaction itself to TritBuf. Also derive macros of Serialize and Desrialze for them. 
Bundles and their builder types will implement and test later.