### PR TITLE
bee-ternary: fix length of trits

### DIFF
--- a/bee-ternary/src/lib.rs
+++ b/bee-ternary/src/lib.rs
@@ -59,25 +59,25 @@ where
         unsafe { &*(T::empty() as *const _ as *const Self) }
     }
 
-    pub unsafe fn from_raw_unchecked(raw: &[i8]) -> &Self {
-        &*(T::from_raw_unchecked(raw) as *const _ as *const _)
+    pub unsafe fn from_raw_unchecked(raw: &[i8], num_trits: usize) -> &Self {
+        &*(T::from_raw_unchecked(raw, num_trits) as *const _ as *const _)
     }
 
-    pub unsafe fn from_raw_unchecked_mut(raw: &mut [i8]) -> &mut Self {
-        &mut *(T::from_raw_unchecked(raw) as *const _ as *mut _)
+    pub unsafe fn from_raw_unchecked_mut(raw: &mut [i8], num_trits: usize) -> &mut Self {
+        &mut *(T::from_raw_unchecked(raw, num_trits) as *const _ as *mut _)
     }
 
-    pub fn try_from_raw(raw: &[i8]) -> Result<&Self, Error> {
+    pub fn try_from_raw(raw: &[i8], num_trits: usize) -> Result<&Self, Error> {
         if raw.iter().all(T::is_valid) {
-            Ok(unsafe { Self::from_raw_unchecked(raw) })
+            Ok(unsafe { Self::from_raw_unchecked(raw, num_trits) })
         } else {
             Err(Error::InvalidRepr)
         }
     }
 
-    pub fn try_from_raw_mut(raw: &mut [i8]) -> Result<&mut Self, Error> {
+    pub fn try_from_raw_mut(raw: &mut [i8], num_trits: usize) -> Result<&mut Self, Error> {
         if raw.iter().all(T::is_valid) {
-            Ok(unsafe { Self::from_raw_unchecked_mut(raw) })
+            Ok(unsafe { Self::from_raw_unchecked_mut(raw, num_trits) })
         } else {
             Err(Error::InvalidRepr)
         }

--- a/bee-ternary/src/raw.rs
+++ b/bee-ternary/src/raw.rs
@@ -30,10 +30,10 @@ pub trait RawEncoding {
     fn is_valid(repr: &i8) -> bool;
 
     /// Unsafely reinterpret a slice of bytes as trit slice
-    unsafe fn from_raw_unchecked(b: &[i8]) -> &Self;
+    unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self;
 
     /// Unsafely reinterpret a slice of bytes as trit slice
-    unsafe fn from_raw_unchecked_mut(b: &mut [i8]) -> &mut Self;
+    unsafe fn from_raw_unchecked_mut(b: &mut [i8], num_trits: usize) -> &mut Self;
 }
 
 pub trait RawEncodingBuf {

--- a/bee-ternary/src/serde.rs
+++ b/bee-ternary/src/serde.rs
@@ -11,15 +11,7 @@ use serde::{
     Deserializer,
     de::{Visitor, SeqAccess, Error, Unexpected},
 };
-use crate::{
-    Trit,
-    Btrit,
-    Utrit,
-    Trits,
-    TritBuf,
-    RawEncoding,
-    RawEncodingBuf,
-};
+use crate::{Trit, Btrit, Utrit, Trits, TritBuf, RawEncoding, RawEncodingBuf, T5B1};
 
 // Serialisation
 
@@ -36,7 +28,8 @@ impl Serialize for Utrit {
 }
 
 impl<'a, T: RawEncoding> Serialize for &'a Trits<T>
-    where T::Trit: Serialize
+    where T::Trit: Serialize,
+          T : serde::Serialize
 {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut seq = serializer.serialize_seq(Some(self.len()))?;

--- a/bee-ternary/src/t1b1.rs
+++ b/bee-ternary/src/t1b1.rs
@@ -83,12 +83,12 @@ where
         TryInto::<T>::try_into(*b).is_ok()
     }
 
-    unsafe fn from_raw_unchecked(b: &[i8]) -> &Self {
-        &*Self::make(b.as_ptr() as *const _, 0, b.len())
+    unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {
+        &*Self::make(b.as_ptr() as *const _, 0, num_trits)
     }
 
-    unsafe fn from_raw_unchecked_mut(b: &mut [i8]) -> &mut Self {
-        &mut *(Self::make(b.as_ptr() as *const _, 0, b.len()) as *mut _)
+    unsafe fn from_raw_unchecked_mut(b: &mut [i8], num_trits: usize) -> &mut Self {
+        &mut *(Self::make(b.as_ptr() as *const _, 0, num_trits) as *mut _)
     }
 }
 

--- a/bee-ternary/src/t1b1.rs
+++ b/bee-ternary/src/t1b1.rs
@@ -84,10 +84,12 @@ where
     }
 
     unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {
+        debug_assert!(num_trits == b.len());
         &*Self::make(b.as_ptr() as *const _, 0, num_trits)
     }
 
     unsafe fn from_raw_unchecked_mut(b: &mut [i8], num_trits: usize) -> &mut Self {
+        debug_assert!(num_trits == b.len());
         &mut *(Self::make(b.as_ptr() as *const _, 0, num_trits) as *mut _)
     }
 }

--- a/bee-ternary/src/t2b1.rs
+++ b/bee-ternary/src/t2b1.rs
@@ -83,10 +83,12 @@ impl RawEncoding for T2B1 {
     fn is_valid(b: &i8) -> bool { *b >= -BAL && *b <= BAL }
 
     unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {
+        debug_assert!(num_trits <= b.len()*TPB);
         &*Self::make(b.as_ptr() as *const _, 0, num_trits)
     }
 
     unsafe fn from_raw_unchecked_mut(b: &mut [i8], num_trits: usize) -> &mut Self {
+        debug_assert!(num_trits <= b.len()*TPB);
         &mut *(Self::make(b.as_ptr() as *const _, 0, num_trits) as *mut _)
     }
 }

--- a/bee-ternary/src/t2b1.rs
+++ b/bee-ternary/src/t2b1.rs
@@ -54,11 +54,11 @@ impl RawEncoding for T2B1 {
     }
 
     fn as_i8_slice(&self) -> &[i8] {
-        unsafe { &*(Self::make(self.ptr(0), 0, self.len()) as *const _) }
+        unsafe { &*(Self::make(self.ptr(0), 0, (self.len() as f32/TPB as f32).ceil() as usize) as *const _) }
     }
 
     unsafe fn as_i8_slice_mut(&mut self) -> &mut [i8] {
-        &mut *(Self::make(self.ptr(0), 0, self.len()) as *mut _)
+        &mut *(Self::make(self.ptr(0), 0, (self.len() as f32/TPB as f32).ceil() as usize) as *mut _)
     }
 
     unsafe fn get_unchecked(&self, index: usize) -> Self::Trit {
@@ -82,12 +82,12 @@ impl RawEncoding for T2B1 {
 
     fn is_valid(b: &i8) -> bool { *b >= -BAL && *b <= BAL }
 
-    unsafe fn from_raw_unchecked(b: &[i8]) -> &Self {
-        &*Self::make(b.as_ptr() as *const _, 0, b.len() * TPB)
+    unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {
+        &*Self::make(b.as_ptr() as *const _, 0, num_trits)
     }
 
-    unsafe fn from_raw_unchecked_mut(b: &mut [i8]) -> &mut Self {
-        &mut *(Self::make(b.as_ptr() as *const _, 0, b.len() * TPB) as *mut _)
+    unsafe fn from_raw_unchecked_mut(b: &mut [i8], num_trits: usize) -> &mut Self {
+        &mut *(Self::make(b.as_ptr() as *const _, 0, num_trits) as *mut _)
     }
 }
 

--- a/bee-ternary/src/t3b1.rs
+++ b/bee-ternary/src/t3b1.rs
@@ -60,11 +60,11 @@ impl RawEncoding for T3B1 {
     }
 
     fn as_i8_slice(&self) -> &[i8] {
-        unsafe { &*(Self::make(self.ptr(0), 0, self.len()) as *const _) }
+        unsafe { &*(Self::make(self.ptr(0), 0, (self.len() as f32/TPB as f32).ceil() as usize) as *const _) }
     }
 
     unsafe fn as_i8_slice_mut(&mut self) -> &mut [i8] {
-        &mut *(Self::make(self.ptr(0), 0, self.len()) as *mut _)
+        &mut *(Self::make(self.ptr(0), 0, (self.len() as f32/TPB as f32).ceil() as usize) as *mut _)
     }
 
     unsafe fn get_unchecked(&self, index: usize) -> Self::Trit {
@@ -88,12 +88,12 @@ impl RawEncoding for T3B1 {
 
     fn is_valid(b: &i8) -> bool { *b >= -BAL && *b <= BAL }
 
-    unsafe fn from_raw_unchecked(b: &[i8]) -> &Self {
-        &*Self::make(b.as_ptr() as *const _, 0, b.len() * TPB)
+    unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {
+        &*Self::make(b.as_ptr() as *const _, 0, num_trits)
     }
 
-    unsafe fn from_raw_unchecked_mut(b: &mut [i8]) -> &mut Self {
-        &mut *(Self::make(b.as_ptr() as *const _, 0, b.len() * TPB) as *mut _)
+    unsafe fn from_raw_unchecked_mut(b: &mut [i8], num_trits: usize) -> &mut Self {
+        &mut *(Self::make(b.as_ptr() as *const _, 0, num_trits) as *mut _)
     }
 }
 

--- a/bee-ternary/src/t3b1.rs
+++ b/bee-ternary/src/t3b1.rs
@@ -89,10 +89,12 @@ impl RawEncoding for T3B1 {
     fn is_valid(b: &i8) -> bool { *b >= -BAL && *b <= BAL }
 
     unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {
+        debug_assert!(num_trits <= b.len()*TPB);
         &*Self::make(b.as_ptr() as *const _, 0, num_trits)
     }
 
     unsafe fn from_raw_unchecked_mut(b: &mut [i8], num_trits: usize) -> &mut Self {
+        debug_assert!(num_trits <= b.len()*TPB);
         &mut *(Self::make(b.as_ptr() as *const _, 0, num_trits) as *mut _)
     }
 }

--- a/bee-ternary/src/t4b1.rs
+++ b/bee-ternary/src/t4b1.rs
@@ -54,11 +54,11 @@ impl RawEncoding for T4B1 {
     }
 
     fn as_i8_slice(&self) -> &[i8] {
-        unsafe { &*(Self::make(self.ptr(0), 0, self.len()) as *const _) }
+        unsafe { &*(Self::make(self.ptr(0), 0, (self.len() as f32 / TPB as f32).ceil() as usize) as *const _) }
     }
 
     unsafe fn as_i8_slice_mut(&mut self) -> &mut [i8] {
-        &mut *(Self::make(self.ptr(0), 0, self.len()) as *mut _)
+        &mut *(Self::make(self.ptr(0), 0, (self.len() as f32 / TPB as f32).ceil() as usize) as *mut _)
     }
 
     unsafe fn get_unchecked(&self, index: usize) -> Self::Trit {
@@ -82,12 +82,12 @@ impl RawEncoding for T4B1 {
 
     fn is_valid(b: &i8) -> bool { *b >= -BAL && *b <= BAL }
 
-    unsafe fn from_raw_unchecked(b: &[i8]) -> &Self {
-        &*Self::make(b.as_ptr() as *const _, 0, b.len() * TPB)
+    unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {
+        &*Self::make(b.as_ptr() as *const _, 0, num_trits)
     }
 
-    unsafe fn from_raw_unchecked_mut(b: &mut [i8]) -> &mut Self {
-        &mut *(Self::make(b.as_ptr() as *const _, 0, b.len() * TPB) as *mut _)
+    unsafe fn from_raw_unchecked_mut(b: &mut [i8], num_trits: usize) -> &mut Self {
+        &mut *(Self::make(b.as_ptr() as *const _, 0, num_trits) as *mut _)
     }
 }
 

--- a/bee-ternary/src/t4b1.rs
+++ b/bee-ternary/src/t4b1.rs
@@ -83,10 +83,12 @@ impl RawEncoding for T4B1 {
     fn is_valid(b: &i8) -> bool { *b >= -BAL && *b <= BAL }
 
     unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {
+        debug_assert!(num_trits <= b.len()*TPB);
         &*Self::make(b.as_ptr() as *const _, 0, num_trits)
     }
 
     unsafe fn from_raw_unchecked_mut(b: &mut [i8], num_trits: usize) -> &mut Self {
+        debug_assert!(num_trits <= b.len()*TPB);
         &mut *(Self::make(b.as_ptr() as *const _, 0, num_trits) as *mut _)
     }
 }

--- a/bee-ternary/src/t5b1.rs
+++ b/bee-ternary/src/t5b1.rs
@@ -84,10 +84,12 @@ impl RawEncoding for T5B1 {
     fn is_valid(b: &i8) -> bool { *b >= -BAL && *b <= BAL }
 
     unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {
+        debug_assert!(num_trits <= b.len()*TPB);
         &*Self::make(b.as_ptr() as *const _, 0, num_trits)
     }
 
     unsafe fn from_raw_unchecked_mut(b: &mut [i8], num_trits: usize) -> &mut Self {
+        debug_assert!(num_trits <= b.len()*TPB);
         &mut *(Self::make(b.as_ptr() as *const _, 0, num_trits) as *mut _)
     }
 }

--- a/bee-ternary/src/t5b1.rs
+++ b/bee-ternary/src/t5b1.rs
@@ -1,5 +1,6 @@
 use std::ops::Range;
 use crate::{Btrit, Utrit, RawEncoding, RawEncodingBuf, ShiftTernary};
+use std::borrow::BorrowMut;
 
 const TPB: usize = 5;
 const BAL: i8 = 121;
@@ -54,11 +55,11 @@ impl RawEncoding for T5B1 {
     }
 
     fn as_i8_slice(&self) -> &[i8] {
-        unsafe { &*(Self::make(self.ptr(0), 0, self.len()) as *const _) }
+        unsafe { std::slice::from_raw_parts(self.ptr(0) as *const _, (self.len() + self.len_offset().1 + TPB - 1) / TPB) }
     }
 
     unsafe fn as_i8_slice_mut(&mut self) -> &mut [i8] {
-        &mut *(Self::make(self.ptr(0), 0, self.len()) as *mut _)
+        unsafe { std::slice::from_raw_parts_mut(self.ptr(0) as *mut _, (self.len() + self.len_offset().1 + TPB - 1) / TPB)}
     }
 
     unsafe fn get_unchecked(&self, index: usize) -> Self::Trit {
@@ -82,12 +83,12 @@ impl RawEncoding for T5B1 {
 
     fn is_valid(b: &i8) -> bool { *b >= -BAL && *b <= BAL }
 
-    unsafe fn from_raw_unchecked(b: &[i8]) -> &Self {
-        &*Self::make(b.as_ptr() as *const _, 0, b.len() * TPB)
+    unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {
+        &*Self::make(b.as_ptr() as *const _, 0, num_trits)
     }
 
-    unsafe fn from_raw_unchecked_mut(b: &mut [i8]) -> &mut Self {
-        &mut *(Self::make(b.as_ptr() as *const _, 0, b.len() * TPB) as *mut _)
+    unsafe fn from_raw_unchecked_mut(b: &mut [i8], num_trits: usize) -> &mut Self {
+        &mut *(Self::make(b.as_ptr() as *const _, 0, num_trits) as *mut _)
     }
 }
 

--- a/bee-ternary/tests/buf.rs
+++ b/bee-ternary/tests/buf.rs
@@ -88,14 +88,14 @@ fn encode_generic<T: raw::RawEncodingBuf + Clone, U: raw::RawEncodingBuf>()
 where
     U::Slice: raw::RawEncoding<Trit = <T::Slice as raw::RawEncoding>::Trit>,
 {
-    fuzz(100, || {
+    fuzz(49, || {
         let a = gen_buf::<T>(0..100).0;
-        let b = a.clone().into_encoding::<U>();
+        let b = a.clone().encode::<U>();
 
         assert_eq!(a, b);
         assert_eq!(a.len(), b.len());
 
-        let c = b.into_encoding::<T>();
+        let c = b.encode::<T>();
 
         assert_eq!(a, c);
         assert_eq!(a.len(), c.len());


### PR DESCRIPTION
- Add num_trits argument because buffer size * TPB is padding