### PR TITLE
Fix the place to actually do bundle normalization

### DIFF
--- a/bee-bundle/src/bundle/outgoing_bundle_builder.rs
+++ b/bee-bundle/src/bundle/outgoing_bundle_builder.rs
@@ -99,7 +99,6 @@ where
                 .squeeze()
                 .unwrap_or_else(|_| panic!("Panicked when unwrapping the sponge hash function."));
 
-            let hash = normalize_hash(&hash);
             let mut has_m_bug = false;
             for trits in hash.chunks(3) {
                 let mut is_m = true;
@@ -271,7 +270,7 @@ impl<E: Sponge + Default> StagedOutgoingBundleBuilder<E, OutgoingSealed> {
         inputs: &[(u64, Address, WotsSecurityLevel)],
     ) -> Result<StagedOutgoingBundleBuilder<E, OutgoingSigned>, OutgoingBundleBuilderError> {
         // Safe to unwrap because bundle is sealed
-        let message = self.builders.0.get(0).unwrap().bundle.as_ref().unwrap();
+        let message = normalize_hash(self.builders.0.get(0).unwrap().bundle.as_ref().unwrap().to_inner());
 
         let mut signature_fragments: Vec<Payload> = Vec::new();
 
@@ -285,7 +284,7 @@ impl<E: Sponge + Default> StagedOutgoingBundleBuilder<E, OutgoingSealed> {
             let signature = key_generator
                 .generate(seed, *index)
                 .map_err(|_| OutgoingBundleBuilderError::FailedSigningOperation)?
-                .sign(message.to_inner().as_i8_slice())
+                .sign(message.as_i8_slice())
                 .map_err(|_| OutgoingBundleBuilderError::FailedSigningOperation)?;
 
             // Split signature into fragments

--- a/bee-bundle/src/bundle/outgoing_bundle_builder.rs
+++ b/bee-bundle/src/bundle/outgoing_bundle_builder.rs
@@ -100,7 +100,7 @@ where
                 .unwrap_or_else(|_| panic!("Panicked when unwrapping the sponge hash function."));
 
             let mut has_m_bug = false;
-            for trits in hash.chunks(3) {
+            for trits in normalize_hash(&hash).chunks(3) {
                 let mut is_m = true;
 
                 for trit in trits.iter() {


### PR DESCRIPTION
The bundle hash shown in the transactions doesn't do normalization. Move bundle normalization to the signing phase.