### PR TITLE
Fixed tryte i8 slice coercion UB

### DIFF
--- a/bee-ternary/src/t2b1.rs
+++ b/bee-ternary/src/t2b1.rs
@@ -35,22 +35,16 @@ impl T2B1 {
 }
 
 fn extract(x: i8, elem: usize) -> Btrit {
-    if elem < TPB {
-        Utrit::from_u8((((x + BAL) / 3i8.pow(elem as u32)) % 3) as u8).shift()
-    } else {
-        unreachable!("Attempted to extract invalid element {} from balanced T2B1", elem)
-    }
+    debug_assert!(elem < TPB, "Attempted to extract invalid element {} from balanced T2B1 trit", elem);
+    Utrit::from_u8((((x + BAL) / 3i8.pow(elem as u32)) % 3) as u8).shift()
 }
 
 fn insert(x: i8, elem: usize, trit: Btrit) -> i8 {
-    if elem < TPB {
-        let utrit = trit.shift();
-        let ux = x + BAL;
-        let ux = ux + (utrit.into_u8() as i8 - (ux / 3i8.pow(elem as u32)) % 3) * 3i8.pow(elem as u32);
-        ux - BAL
-    } else {
-        unreachable!("Attempted to insert invalid element {} into balanced T2B1", elem)
-    }
+    debug_assert!(elem < TPB, "Attempted to insert invalid element {} into balanced T2B1 trit", elem);
+    let utrit = trit.shift();
+    let ux = x + BAL;
+    let ux = ux + (utrit.into_u8() as i8 - (ux / 3i8.pow(elem as u32)) % 3) * 3i8.pow(elem as u32);
+    ux - BAL
 }
 
 impl RawEncoding for T2B1 {
@@ -67,12 +61,18 @@ impl RawEncoding for T2B1 {
 
     fn as_i8_slice(&self) -> &[i8] {
         assert!(self.len_offset().1 == 0);
-        unsafe { &*(Self::make(self.ptr(0), 0, (self.len() as f32 / TPB as f32).ceil() as usize) as *const _) }
+        unsafe { std::slice::from_raw_parts(
+            self as *const _ as *const _,
+            (self.len() + TPB - 1) / TPB,
+        ) }
     }
 
     unsafe fn as_i8_slice_mut(&mut self) -> &mut [i8] {
         assert!(self.len_offset().1 == 0);
-        &mut *(Self::make(self.ptr(0), 0, (self.len() as f32 / TPB as f32).ceil() as usize) as *mut _)
+        std::slice::from_raw_parts_mut(
+            self as *mut _ as *mut _,
+            (self.len() + TPB - 1) / TPB,
+        )
     }
 
     unsafe fn get_unchecked(&self, index: usize) -> Self::Trit {
@@ -107,12 +107,12 @@ impl RawEncoding for T2B1 {
     }
 
     unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {
-        debug_assert!(num_trits <= b.len() * TPB);
+        assert!(num_trits <= b.len() * TPB);
         &*Self::make(b.as_ptr() as *const _, 0, num_trits)
     }
 
     unsafe fn from_raw_unchecked_mut(b: &mut [i8], num_trits: usize) -> &mut Self {
-        debug_assert!(num_trits <= b.len() * TPB);
+        assert!(num_trits <= b.len() * TPB);
         &mut *(Self::make(b.as_ptr() as *const _, 0, num_trits) as *mut _)
     }
 }

--- a/bee-ternary/src/t4b1.rs
+++ b/bee-ternary/src/t4b1.rs
@@ -35,22 +35,16 @@ impl T4B1 {
 }
 
 fn extract(x: i8, elem: usize) -> Btrit {
-    if elem < TPB {
-        Utrit::from_u8((((x + BAL) / 3i8.pow(elem as u32)) % 3) as u8).shift()
-    } else {
-        unreachable!("Attempted to extract invalid element {} from balanced T4B1", elem)
-    }
+    debug_assert!(elem < TPB, "Attempted to extract invalid element {} from balanced T4B1 trit", elem);
+    Utrit::from_u8((((x + BAL) / 3i8.pow(elem as u32)) % 3) as u8).shift()
 }
 
 fn insert(x: i8, elem: usize, trit: Btrit) -> i8 {
-    if elem < TPB {
-        let utrit = trit.shift();
-        let ux = x + BAL;
-        let ux = ux + (utrit.into_u8() as i8 - (ux / 3i8.pow(elem as u32)) % 3) * 3i8.pow(elem as u32);
-        ux - BAL
-    } else {
-        unreachable!("Attempted to insert invalid element {} into balanced T4B1", elem)
-    }
+    debug_assert!(elem < TPB, "Attempted to insert invalid element {} into balanced T4B1 trit", elem);
+    let utrit = trit.shift();
+    let ux = x + BAL;
+    let ux = ux + (utrit.into_u8() as i8 - (ux / 3i8.pow(elem as u32)) % 3) * 3i8.pow(elem as u32);
+    ux - BAL
 }
 
 impl RawEncoding for T4B1 {
@@ -67,12 +61,18 @@ impl RawEncoding for T4B1 {
 
     fn as_i8_slice(&self) -> &[i8] {
         assert!(self.len_offset().1 == 0);
-        unsafe { &*(Self::make(self.ptr(0), 0, (self.len() as f32 / TPB as f32).ceil() as usize) as *const _) }
+        unsafe { std::slice::from_raw_parts(
+            self as *const _ as *const _,
+            (self.len() + TPB - 1) / TPB,
+        ) }
     }
 
     unsafe fn as_i8_slice_mut(&mut self) -> &mut [i8] {
         assert!(self.len_offset().1 == 0);
-        &mut *(Self::make(self.ptr(0), 0, (self.len() as f32 / TPB as f32).ceil() as usize) as *mut _)
+        std::slice::from_raw_parts_mut(
+            self as *mut _ as *mut _,
+            (self.len() + TPB - 1) / TPB,
+        )
     }
 
     unsafe fn get_unchecked(&self, index: usize) -> Self::Trit {
@@ -107,12 +107,12 @@ impl RawEncoding for T4B1 {
     }
 
     unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {
-        debug_assert!(num_trits <= b.len() * TPB);
+        assert!(num_trits <= b.len() * TPB);
         &*Self::make(b.as_ptr() as *const _, 0, num_trits)
     }
 
     unsafe fn from_raw_unchecked_mut(b: &mut [i8], num_trits: usize) -> &mut Self {
-        debug_assert!(num_trits <= b.len() * TPB);
+        assert!(num_trits <= b.len() * TPB);
         &mut *(Self::make(b.as_ptr() as *const _, 0, num_trits) as *mut _)
     }
 }

--- a/bee-ternary/src/t5b1.rs
+++ b/bee-ternary/src/t5b1.rs
@@ -35,22 +35,16 @@ impl T5B1 {
 }
 
 fn extract(x: i8, elem: usize) -> Btrit {
-    if elem < TPB {
-        Utrit::from_u8((((x as i16 + BAL as i16) / 3i16.pow(elem as u32)) % 3) as u8).shift()
-    } else {
-        unreachable!("Attempted to extract invalid element {} from balanced T5B1", elem)
-    }
+    debug_assert!(elem < TPB, "Attempted to extract invalid element {} from balanced T5B1 trit", elem);
+    Utrit::from_u8((((x as i16 + BAL as i16) / 3i16.pow(elem as u32)) % 3) as u8).shift()
 }
 
 fn insert(x: i8, elem: usize, trit: Btrit) -> i8 {
-    if elem < TPB {
-        let utrit = trit.shift();
-        let ux = x as i16 + BAL as i16;
-        let ux = ux + (utrit.into_u8() as i16 - (ux / 3i16.pow(elem as u32)) % 3) * 3i16.pow(elem as u32);
-        (ux - BAL as i16) as i8
-    } else {
-        unreachable!("Attempted to insert invalid element {} into balanced T5B1", elem)
-    }
+    debug_assert!(elem < TPB, "Attempted to insert invalid element {} into balanced T5B1 trit", elem);
+    let utrit = trit.shift();
+    let ux = x as i16 + BAL as i16;
+    let ux = ux + (utrit.into_u8() as i16 - (ux / 3i16.pow(elem as u32)) % 3) * 3i16.pow(elem as u32);
+    (ux - BAL as i16) as i8
 }
 
 impl RawEncoding for T5B1 {
@@ -67,19 +61,17 @@ impl RawEncoding for T5B1 {
 
     fn as_i8_slice(&self) -> &[i8] {
         assert!(self.len_offset().1 == 0);
-        unsafe {
-            std::slice::from_raw_parts(
-                self.ptr(0) as *const _,
-                (self.len() + self.len_offset().1 + TPB - 1) / TPB,
-            )
-        }
+        unsafe { std::slice::from_raw_parts(
+            self as *const _ as *const _,
+            (self.len() + TPB - 1) / TPB,
+        ) }
     }
 
     unsafe fn as_i8_slice_mut(&mut self) -> &mut [i8] {
         assert!(self.len_offset().1 == 0);
         std::slice::from_raw_parts_mut(
-            self.ptr(0) as *mut _,
-            (self.len() + self.len_offset().1 + TPB - 1) / TPB,
+            self as *mut _ as *mut _,
+            (self.len() + TPB - 1) / TPB,
         )
     }
 
@@ -115,12 +107,12 @@ impl RawEncoding for T5B1 {
     }
 
     unsafe fn from_raw_unchecked(b: &[i8], num_trits: usize) -> &Self {
-        debug_assert!(num_trits <= b.len() * TPB);
+        assert!(num_trits <= b.len() * TPB);
         &*Self::make(b.as_ptr() as *const _, 0, num_trits)
     }
 
     unsafe fn from_raw_unchecked_mut(b: &mut [i8], num_trits: usize) -> &mut Self {
-        debug_assert!(num_trits <= b.len() * TPB);
+        assert!(num_trits <= b.len() * TPB);
         &mut *(Self::make(b.as_ptr() as *const _, 0, num_trits) as *mut _)
     }
 }

--- a/bee-ternary/src/tryte.rs
+++ b/bee-ternary/src/tryte.rs
@@ -68,7 +68,7 @@ impl From<Tryte> for char {
             0 => '9',
             -13..=-1 => (((tryte as i8 + 13) as u8) + b'N') as char,
             1..=13 => (((tryte as i8 - 1) as u8) + b'A') as char,
-            _ => unreachable!(),
+            x => unreachable!("Tried to decode Tryte with variant {}", x),
         }
     }
 }
@@ -186,5 +186,21 @@ impl fmt::Display for TryteBuf {
             write!(f, "{}", tryte)?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::*;
+
+    #[test]
+    fn zeroes() {
+        let _ = TritBuf::<T3B1Buf>::filled(243, Btrit::Zero)
+            .encode::<T3B1Buf>()
+            .as_trytes()
+            .iter()
+            .map(|t| char::from(*t))
+            .collect::<String>();
     }
 }


### PR DESCRIPTION
The coercion of trit slices to `&[i8]` was implemented incorrectly, causing the resulting fat pointer to be malformed, reporting the wrong length to the tryte code. This meant that the tryte code was reading out-of-bounds bytes and attempting to interpret them as valid trytes, and failing to do so since the values were undefined. This PR fixes this issue after a long of head-scratching and also brings along a bunch of performance improvements for release builds!

I've also added a test that should catch this issue should it somehow be accidentally reintroduced.