### PR TITLE
expose tangle flags to be able to insert transactions from other crat…

### DIFF
--- a/bee-protocol/src/tangle/mod.rs
+++ b/bee-protocol/src/tangle/mod.rs
@@ -9,7 +9,7 @@
 // an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and limitations under the License.
 
-pub(crate) mod flags;
+pub mod flags;
 
 // TODO: reinstate the async worker
 // pub(crate) mod propagator;


### PR DESCRIPTION
To be able to add transactions from external crates e.g. bee-api to the protocol-tangle, 'tangle::flag::Flags' must be exposed since it's required by `insert(&self, transaction: Tx, hash: TxHash, flags: Flags) `