### PR TITLE
Refactor workers

### DIFF
--- a/bee-common-ext/src/lib.rs
+++ b/bee-common-ext/src/lib.rs
@@ -12,5 +12,5 @@
 //! A crate that provides common functionalities shared across multiple crates within the Bee framework, and for
 //! applications built on-top.
 
-pub mod wait_priority_queue;
 pub mod event;
+pub mod wait_priority_queue;

--- a/bee-protocol/src/protocol/helpers.rs
+++ b/bee-protocol/src/protocol/helpers.rs
@@ -113,7 +113,7 @@ impl Protocol {
             .milestone_solidifier_worker
             // TODO try to avoid clone
             .clone()
-            .send(MilestoneSolidifierWorkerEvent())
+            .send(MilestoneSolidifierWorkerEvent)
             .await
         {
             warn!("Triggering milestone solidification failed: {}.", e);

--- a/bee-protocol/src/protocol/protocol.rs
+++ b/bee-protocol/src/protocol/protocol.rs
@@ -207,10 +207,13 @@ impl Protocol {
 
         shutdown.add_worker_shutdown(
             transaction_solidifier_worker_shutdown_tx,
-            spawn(TransactionSolidifierWorker::new().run(
-                transaction_solidifier_worker_rx,
-                transaction_solidifier_worker_shutdown_rx,
-            )),
+            spawn(
+                TransactionSolidifierWorker::new(Receiver::new(
+                    transaction_solidifier_worker_rx,
+                    transaction_solidifier_worker_shutdown_rx,
+                ))
+                .run(),
+            ),
         );
 
         shutdown.add_worker_shutdown(

--- a/bee-protocol/src/protocol/protocol.rs
+++ b/bee-protocol/src/protocol/protocol.rs
@@ -20,14 +20,14 @@ use crate::{
         BroadcasterWorker, BroadcasterWorkerEvent, MilestoneRequesterWorker, MilestoneRequesterWorkerEntry,
         MilestoneResponderWorker, MilestoneResponderWorkerEvent, MilestoneSolidifierWorker,
         MilestoneSolidifierWorkerEvent, MilestoneValidatorWorker, MilestoneValidatorWorkerEvent, PeerHandshakerWorker,
-        StatusWorker, TpsWorker, TransactionRequesterWorker, TransactionRequesterWorkerEntry,
+        Receiver, StatusWorker, TpsWorker, TransactionRequesterWorker, TransactionRequesterWorkerEntry,
         TransactionResponderWorker, TransactionResponderWorkerEvent, TransactionSolidifierWorker,
         TransactionSolidifierWorkerEvent, TransactionWorker, TransactionWorkerEvent,
     },
 };
 
 use bee_common::shutdown::Shutdown;
-use bee_common_ext::{wait_priority_queue::WaitPriorityQueue, event::Bus};
+use bee_common_ext::{event::Bus, wait_priority_queue::WaitPriorityQueue};
 use bee_crypto::ternary::{
     sponge::{CurlP27, CurlP81, Kerl, SpongeKind},
     Hash,
@@ -134,24 +134,31 @@ impl Protocol {
                 TransactionWorker::new(
                     Protocol::get().milestone_validator_worker.clone(),
                     Protocol::get().config.workers.transaction_worker_cache,
+                    Receiver::new(transaction_worker_rx, transaction_worker_shutdown_rx),
                 )
-                .run(transaction_worker_rx, transaction_worker_shutdown_rx),
+                .run(),
             ),
         );
 
         shutdown.add_worker_shutdown(
             transaction_responder_worker_shutdown_tx,
-            spawn(TransactionResponderWorker::new().run(
-                transaction_responder_worker_rx,
-                transaction_responder_worker_shutdown_rx,
-            )),
+            spawn(
+                TransactionResponderWorker::new(Receiver::new(
+                    transaction_responder_worker_rx,
+                    transaction_responder_worker_shutdown_rx,
+                ))
+                .run(),
+            ),
         );
 
         shutdown.add_worker_shutdown(
             milestone_responder_worker_shutdown_tx,
             spawn(
-                MilestoneResponderWorker::new()
-                    .run(milestone_responder_worker_rx, milestone_responder_worker_shutdown_rx),
+                MilestoneResponderWorker::new(Receiver::new(
+                    milestone_responder_worker_rx,
+                    milestone_responder_worker_shutdown_rx,
+                ))
+                .run(),
             ),
         );
 
@@ -169,22 +176,31 @@ impl Protocol {
             SpongeKind::Kerl => shutdown.add_worker_shutdown(
                 milestone_validator_worker_shutdown_tx,
                 spawn(
-                    MilestoneValidatorWorker::<Kerl, WotsPublicKey<Kerl>>::new()
-                        .run(milestone_validator_worker_rx, milestone_validator_worker_shutdown_rx),
+                    MilestoneValidatorWorker::<Kerl, WotsPublicKey<Kerl>>::new(Receiver::new(
+                        milestone_validator_worker_rx,
+                        milestone_validator_worker_shutdown_rx,
+                    ))
+                    .run(),
                 ),
             ),
             SpongeKind::CurlP27 => shutdown.add_worker_shutdown(
                 milestone_validator_worker_shutdown_tx,
                 spawn(
-                    MilestoneValidatorWorker::<CurlP27, WotsPublicKey<CurlP27>>::new()
-                        .run(milestone_validator_worker_rx, milestone_validator_worker_shutdown_rx),
+                    MilestoneValidatorWorker::<CurlP27, WotsPublicKey<CurlP27>>::new(Receiver::new(
+                        milestone_validator_worker_rx,
+                        milestone_validator_worker_shutdown_rx,
+                    ))
+                    .run(),
                 ),
             ),
             SpongeKind::CurlP81 => shutdown.add_worker_shutdown(
                 milestone_validator_worker_shutdown_tx,
                 spawn(
-                    MilestoneValidatorWorker::<CurlP81, WotsPublicKey<CurlP81>>::new()
-                        .run(milestone_validator_worker_rx, milestone_validator_worker_shutdown_rx),
+                    MilestoneValidatorWorker::<CurlP81, WotsPublicKey<CurlP81>>::new(Receiver::new(
+                        milestone_validator_worker_rx,
+                        milestone_validator_worker_shutdown_rx,
+                    ))
+                    .run(),
                 ),
             ),
         };
@@ -200,14 +216,23 @@ impl Protocol {
         shutdown.add_worker_shutdown(
             milestone_solidifier_worker_shutdown_tx,
             spawn(
-                MilestoneSolidifierWorker::new()
-                    .run(milestone_solidifier_worker_rx, milestone_solidifier_worker_shutdown_rx),
+                MilestoneSolidifierWorker::new(Receiver::new(
+                    milestone_solidifier_worker_rx,
+                    milestone_solidifier_worker_shutdown_rx,
+                ))
+                .run(),
             ),
         );
 
         shutdown.add_worker_shutdown(
             broadcaster_worker_shutdown_tx,
-            spawn(BroadcasterWorker::new(network).run(broadcaster_worker_rx, broadcaster_worker_shutdown_rx)),
+            spawn(
+                BroadcasterWorker::new(
+                    network,
+                    Receiver::new(broadcaster_worker_rx, broadcaster_worker_shutdown_rx),
+                )
+                .run(),
+            ),
         );
 
         shutdown.add_worker_shutdown(

--- a/bee-protocol/src/worker/broadcaster.rs
+++ b/bee-protocol/src/worker/broadcaster.rs
@@ -17,7 +17,7 @@ use crate::{
 use bee_common::worker::Error as WorkerError;
 use bee_network::{Command::SendMessage, EndpointId, Network};
 
-use futures::channel::mpsc;
+use futures::{channel::mpsc, stream::StreamExt};
 
 use log::{info, warn};
 
@@ -70,7 +70,7 @@ impl BroadcasterWorker {
     pub(crate) async fn run(mut self) -> Result<(), WorkerError> {
         info!("Running.");
 
-        while let Some(BroadcasterWorkerEvent { source, transaction }) = self.receiver.receive_event().await {
+        while let Some(BroadcasterWorkerEvent { source, transaction }) = self.receiver.next().await {
             self.broadcast(source, transaction).await;
         }
 

--- a/bee-protocol/src/worker/broadcaster.rs
+++ b/bee-protocol/src/worker/broadcaster.rs
@@ -17,13 +17,11 @@ use crate::{
 use bee_common::worker::Error as WorkerError;
 use bee_network::{Command::SendMessage, EndpointId, Network};
 
-use futures::{
-    channel::{mpsc, oneshot},
-    future::FutureExt,
-    select,
-    stream::StreamExt,
-};
+use futures::channel::mpsc;
+
 use log::{info, warn};
+
+type Receiver = crate::worker::Receiver<mpsc::Receiver<BroadcasterWorkerEvent>>;
 
 pub(crate) struct BroadcasterWorkerEvent {
     pub(crate) source: Option<EndpointId>,
@@ -32,11 +30,12 @@ pub(crate) struct BroadcasterWorkerEvent {
 
 pub(crate) struct BroadcasterWorker {
     network: Network,
+    receiver: Receiver,
 }
 
 impl BroadcasterWorker {
-    pub(crate) fn new(network: Network) -> Self {
-        Self { network }
+    pub(crate) fn new(network: Network, receiver: Receiver) -> Self {
+        Self { network, receiver }
     }
 
     async fn broadcast(&mut self, source: Option<EndpointId>, transaction: TransactionMessage) {
@@ -68,25 +67,11 @@ impl BroadcasterWorker {
         }
     }
 
-    pub(crate) async fn run(
-        mut self,
-        receiver: mpsc::Receiver<BroadcasterWorkerEvent>,
-        shutdown: oneshot::Receiver<()>,
-    ) -> Result<(), WorkerError> {
+    pub(crate) async fn run(mut self) -> Result<(), WorkerError> {
         info!("Running.");
 
-        let mut receiver_fused = receiver.fuse();
-        let mut shutdown_fused = shutdown.fuse();
-
-        loop {
-            select! {
-                _ = shutdown_fused => break,
-                transaction = receiver_fused.next() => {
-                    if let Some(BroadcasterWorkerEvent{source, transaction}) = transaction {
-                        self.broadcast(source, transaction).await;
-                    }
-                }
-            }
+        while let Some(BroadcasterWorkerEvent { source, transaction }) = self.receiver.receive_event().await {
+            self.broadcast(source, transaction).await;
         }
 
         info!("Stopped.");

--- a/bee-protocol/src/worker/milestone_validator.rs
+++ b/bee-protocol/src/worker/milestone_validator.rs
@@ -24,15 +24,12 @@ use bee_crypto::ternary::{
 use bee_signing::ternary::{PublicKey, RecoverableSignature};
 use bee_transaction::TransactionVertex;
 
-use futures::{
-    channel::{mpsc, oneshot},
-    future::FutureExt,
-    select,
-    stream::StreamExt,
-};
 use log::{debug, info};
 
+use futures::channel::mpsc;
 use std::marker::PhantomData;
+
+type Receiver = crate::worker::Receiver<mpsc::Receiver<MilestoneValidatorWorkerEvent>>;
 
 #[derive(Debug)]
 pub(crate) enum MilestoneValidatorWorkerError {
@@ -45,6 +42,7 @@ pub(crate) enum MilestoneValidatorWorkerError {
 pub(crate) struct MilestoneValidatorWorkerEvent(pub(crate) Hash);
 
 pub(crate) struct MilestoneValidatorWorker<M, P> {
+    receiver: Receiver,
     mss_sponge: PhantomData<M>,
     public_key: PhantomData<P>,
 }
@@ -55,8 +53,9 @@ where
     P: PublicKey,
     <P as PublicKey>::Signature: RecoverableSignature,
 {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(receiver: Receiver) -> Self {
         Self {
+            receiver,
             mss_sponge: PhantomData,
             public_key: PhantomData,
         }
@@ -124,25 +123,11 @@ where
     }
 
     // TODO PriorityQueue ?
-    pub(crate) async fn run(
-        self,
-        receiver: mpsc::Receiver<MilestoneValidatorWorkerEvent>,
-        shutdown: oneshot::Receiver<()>,
-    ) -> Result<(), WorkerError> {
+    pub(crate) async fn run(mut self) -> Result<(), WorkerError> {
         info!("Running.");
 
-        let mut receiver_fused = receiver.fuse();
-        let mut shutdown_fused = shutdown.fuse();
-
-        loop {
-            select! {
-                _ = shutdown_fused => break,
-                tail_hash = receiver_fused.next() => {
-                    if let Some(MilestoneValidatorWorkerEvent(tail_hash)) = tail_hash {
-                        self.process(tail_hash).await;
-                    }
-                }
-            }
+        while let Some(MilestoneValidatorWorkerEvent(tail_hash)) = self.receiver.receive_event().await {
+            self.process(tail_hash).await;
         }
 
         info!("Stopped.");

--- a/bee-protocol/src/worker/milestone_validator.rs
+++ b/bee-protocol/src/worker/milestone_validator.rs
@@ -26,7 +26,7 @@ use bee_transaction::TransactionVertex;
 
 use log::{debug, info};
 
-use futures::channel::mpsc;
+use futures::{channel::mpsc, stream::StreamExt};
 use std::marker::PhantomData;
 
 type Receiver = crate::worker::Receiver<mpsc::Receiver<MilestoneValidatorWorkerEvent>>;
@@ -126,7 +126,7 @@ where
     pub(crate) async fn run(mut self) -> Result<(), WorkerError> {
         info!("Running.");
 
-        while let Some(MilestoneValidatorWorkerEvent(tail_hash)) = self.receiver.receive_event().await {
+        while let Some(MilestoneValidatorWorkerEvent(tail_hash)) = self.receiver.next().await {
             self.process(tail_hash).await;
         }
 

--- a/bee-protocol/src/worker/milestone_validator.rs
+++ b/bee-protocol/src/worker/milestone_validator.rs
@@ -42,7 +42,7 @@ pub(crate) enum MilestoneValidatorWorkerError {
     InvalidMilestone(MilestoneBuilderError),
 }
 
-pub(crate) type MilestoneValidatorWorkerEvent = Hash;
+pub(crate) struct MilestoneValidatorWorkerEvent(pub(crate) Hash);
 
 pub(crate) struct MilestoneValidatorWorker<M, P> {
     mss_sponge: PhantomData<M>,
@@ -138,7 +138,7 @@ where
             select! {
                 _ = shutdown_fused => break,
                 tail_hash = receiver_fused.next() => {
-                    if let Some(tail_hash) = tail_hash {
+                    if let Some(MilestoneValidatorWorkerEvent(tail_hash)) = tail_hash {
                         self.process(tail_hash).await;
                     }
                 }

--- a/bee-protocol/src/worker/peer/message_handler.rs
+++ b/bee-protocol/src/worker/peer/message_handler.rs
@@ -68,7 +68,10 @@ impl MessageHandler {
                 // Read a header.
                 ReadState::Header => {
                     // We need `HEADER_SIZE` bytes to read a header.
-                    let bytes = self.events.fetch_bytes_or_shutdown(&mut self.shutdown, HEADER_SIZE).await?;
+                    let bytes = self
+                        .events
+                        .fetch_bytes_or_shutdown(&mut self.shutdown, HEADER_SIZE)
+                        .await?;
                     debug!("[{}] Reading Header...", self.address);
                     let header = Header::from_bytes(bytes);
                     // Now we are ready to read a payload.
@@ -77,8 +80,10 @@ impl MessageHandler {
                 // Read a payload.
                 ReadState::Payload(header) => {
                     // We read the quantity of bytes stated by the header.
-                    let bytes =
-                        self.events.fetch_bytes_or_shutdown(&mut self.shutdown, header.message_length.into()).await?;
+                    let bytes = self
+                        .events
+                        .fetch_bytes_or_shutdown(&mut self.shutdown, header.message_length.into())
+                        .await?;
                     // FIXME: Avoid this clone
                     let header = header.clone();
                     // Now we are ready to read the next message's header.
@@ -172,7 +177,8 @@ mod tests {
 
     use futures::{
         channel::{mpsc, oneshot},
-        {future::FutureExt, stream::StreamExt},
+        future::FutureExt,
+        stream::StreamExt,
     };
 
     use async_std::task;

--- a/bee-protocol/src/worker/peer/mod.rs
+++ b/bee-protocol/src/worker/peer/mod.rs
@@ -10,9 +10,9 @@
 // See the License for the specific language governing permissions and limitations under the License.
 
 mod handshaker;
-mod peer;
 mod message_handler;
+mod peer;
 
 pub(crate) use handshaker::PeerHandshakerWorker;
-pub(crate) use peer::PeerWorker;
 use message_handler::MessageHandler;
+pub(crate) use peer::PeerWorker;

--- a/bee-protocol/src/worker/responder/milestone.rs
+++ b/bee-protocol/src/worker/responder/milestone.rs
@@ -21,7 +21,7 @@ use bee_ternary::{T1B1Buf, T5B1Buf, TritBuf};
 use bee_transaction::bundled::BundledTransaction as Transaction;
 
 use bytemuck::cast_slice;
-use futures::channel::mpsc;
+use futures::{channel::mpsc, stream::StreamExt};
 
 use log::info;
 
@@ -70,7 +70,7 @@ impl MilestoneResponderWorker {
     pub(crate) async fn run(mut self) -> Result<(), WorkerError> {
         info!("Running.");
 
-        while let Some(MilestoneResponderWorkerEvent { epid, request }) = self.receiver.receive_event().await {
+        while let Some(MilestoneResponderWorkerEvent { epid, request }) = self.receiver.next().await {
             self.process_request(epid, request).await;
         }
 

--- a/bee-protocol/src/worker/responder/transaction.rs
+++ b/bee-protocol/src/worker/responder/transaction.rs
@@ -22,7 +22,7 @@ use bee_ternary::{T1B1Buf, T5B1Buf, TritBuf, Trits, T5B1};
 use bee_transaction::bundled::{BundledTransaction as Transaction, BundledTransactionField};
 
 use bytemuck::cast_slice;
-use futures::channel::mpsc;
+use futures::{channel::mpsc, stream::StreamExt};
 use log::info;
 
 type Receiver = crate::worker::Receiver<mpsc::Receiver<TransactionResponderWorkerEvent>>;
@@ -68,7 +68,7 @@ impl TransactionResponderWorker {
     pub(crate) async fn run(mut self) -> Result<(), WorkerError> {
         info!("Running.");
 
-        while let Some(TransactionResponderWorkerEvent { epid, request }) = self.receiver.receive_event().await {
+        while let Some(TransactionResponderWorkerEvent { epid, request }) = self.receiver.next().await {
             self.process_request(epid, request).await;
         }
 

--- a/bee-protocol/src/worker/responder/transaction.rs
+++ b/bee-protocol/src/worker/responder/transaction.rs
@@ -22,24 +22,23 @@ use bee_ternary::{T1B1Buf, T5B1Buf, TritBuf, Trits, T5B1};
 use bee_transaction::bundled::{BundledTransaction as Transaction, BundledTransactionField};
 
 use bytemuck::cast_slice;
-use futures::{
-    channel::{mpsc, oneshot},
-    future::FutureExt,
-    select,
-    stream::StreamExt,
-};
+use futures::channel::mpsc;
 use log::info;
+
+type Receiver = crate::worker::Receiver<mpsc::Receiver<TransactionResponderWorkerEvent>>;
 
 pub(crate) struct TransactionResponderWorkerEvent {
     pub(crate) epid: EndpointId,
     pub(crate) request: TransactionRequest,
 }
 
-pub(crate) struct TransactionResponderWorker {}
+pub(crate) struct TransactionResponderWorker {
+    receiver: Receiver,
+}
 
 impl TransactionResponderWorker {
-    pub(crate) fn new() -> Self {
-        Self {}
+    pub(crate) fn new(receiver: Receiver) -> Self {
+        Self { receiver }
     }
 
     async fn process_request(&self, epid: EndpointId, request: TransactionRequest) {
@@ -66,25 +65,11 @@ impl TransactionResponderWorker {
         }
     }
 
-    pub(crate) async fn run(
-        self,
-        receiver: mpsc::Receiver<TransactionResponderWorkerEvent>,
-        shutdown: oneshot::Receiver<()>,
-    ) -> Result<(), WorkerError> {
+    pub(crate) async fn run(mut self) -> Result<(), WorkerError> {
         info!("Running.");
 
-        let mut receiver_fused = receiver.fuse();
-        let mut shutdown_fused = shutdown.fuse();
-
-        loop {
-            select! {
-                _ = shutdown_fused => break,
-                event = receiver_fused.next() => {
-                    if let Some(TransactionResponderWorkerEvent { epid, request }) = event {
-                        self.process_request(epid, request).await;
-                    }
-                }
-            }
+        while let Some(TransactionResponderWorkerEvent { epid, request }) = self.receiver.receive_event().await {
+            self.process_request(epid, request).await;
         }
 
         info!("Stopped.");

--- a/bee-protocol/src/worker/sender.rs
+++ b/bee-protocol/src/worker/sender.rs
@@ -19,31 +19,28 @@ use crate::{
 
 use bee_network::{Command::SendMessage, EndpointId, Network};
 
-use std::{marker::PhantomData, sync::Arc};
+use std::sync::Arc;
 
-use futures::{
-    channel::{mpsc, oneshot},
-    future::FutureExt,
-    select,
-    sink::SinkExt,
-    stream::StreamExt,
-};
+use futures::{sink::SinkExt, channel::mpsc};
+
 use log::warn;
+
+type Receiver<M> = crate::worker::Receiver<mpsc::Receiver<M>>;
 
 pub(crate) struct SenderWorker<M: Message> {
     network: Network,
     peer: Arc<HandshakedPeer>,
-    _message_type: PhantomData<M>,
+    receiver: Receiver<M>,
 }
 
 macro_rules! implement_sender_worker {
     ($type:ty, $sender:tt, $incrementor:tt) => {
         impl SenderWorker<$type> {
-            pub(crate) fn new(network: Network, peer: Arc<HandshakedPeer>) -> Self {
+            pub(crate) fn new(network: Network, peer: Arc<HandshakedPeer>, receiver: Receiver<$type>) -> Self {
                 Self {
                     network,
                     peer,
-                    _message_type: PhantomData,
+                    receiver,
                 }
             }
 
@@ -63,41 +60,24 @@ macro_rules! implement_sender_worker {
                 };
             }
 
-            pub(crate) async fn run(
-                mut self,
-                events_receiver: mpsc::Receiver<$type>,
-                shutdown_receiver: oneshot::Receiver<()>,
-            ) {
-                let mut events_fused = events_receiver.fuse();
-                let mut shutdown_fused = shutdown_receiver.fuse();
-
-                loop {
-                    select! {
-                        _ = shutdown_fused => break,
-                        message = events_fused.next() => {
-                            if let Some(message) = message {
-                                match self
-                                    .network
-                                    .send(SendMessage {
-                                        epid: self.peer.epid,
-                                        bytes: tlv_into_bytes(message),
-                                        responder: None,
-                                    })
-                                    .await
-                                {
-                                    Ok(_) => {
-                                        self.peer.metrics.$incrementor();
-                                        Protocol::get().metrics.$incrementor();
-                                    }
-                                    Err(e) => {
-                                        // TODO log actual message type ?
-                                        warn!(
-                                            "Sending message to {} failed: {:?}.",
-                                            self.peer.epid, e
-                                        );
-                                    }
-                                }
-                            }
+            pub(crate) async fn run(mut self) {
+                while let Some(message) = self.receiver.receive_event().await {
+                    match self
+                        .network
+                        .send(SendMessage {
+                            epid: self.peer.epid,
+                            bytes: tlv_into_bytes(message),
+                            responder: None,
+                        })
+                        .await
+                    {
+                        Ok(_) => {
+                            self.peer.metrics.$incrementor();
+                            Protocol::get().metrics.$incrementor();
+                        }
+                        Err(e) => {
+                            // TODO log actual message type ?
+                            warn!("Sending message to {} failed: {:?}.", self.peer.epid, e);
                         }
                     }
                 }

--- a/bee-protocol/src/worker/sender.rs
+++ b/bee-protocol/src/worker/sender.rs
@@ -21,7 +21,7 @@ use bee_network::{Command::SendMessage, EndpointId, Network};
 
 use std::sync::Arc;
 
-use futures::{sink::SinkExt, channel::mpsc};
+use futures::{channel::mpsc, sink::SinkExt, stream::StreamExt};
 
 use log::warn;
 
@@ -61,7 +61,7 @@ macro_rules! implement_sender_worker {
             }
 
             pub(crate) async fn run(mut self) {
-                while let Some(message) = self.receiver.receive_event().await {
+                while let Some(message) = self.receiver.next().await {
                     match self
                         .network
                         .send(SendMessage {

--- a/bee-protocol/src/worker/solidifier/milestone.rs
+++ b/bee-protocol/src/worker/solidifier/milestone.rs
@@ -13,7 +13,7 @@ use crate::{milestone::MilestoneIndex, protocol::Protocol, tangle::tangle};
 
 use bee_common::worker::Error as WorkerError;
 
-use futures::channel::mpsc;
+use futures::{channel::mpsc, stream::StreamExt};
 use log::info;
 
 const MILESTONE_REQUEST_RANGE: u8 = 50;
@@ -116,7 +116,7 @@ impl MilestoneSolidifierWorker {
     pub(crate) async fn run(mut self) -> Result<(), WorkerError> {
         info!("Running.");
 
-        while let Some(MilestoneSolidifierWorkerEvent) = self.receiver.receive_event().await {
+        while let Some(MilestoneSolidifierWorkerEvent) = self.receiver.next().await {
             self.request_milestones();
             self.solidify_milestone().await;
             // while tangle().get_last_solid_milestone_index() < tangle().get_last_milestone_index() {

--- a/bee-protocol/src/worker/solidifier/milestone.rs
+++ b/bee-protocol/src/worker/solidifier/milestone.rs
@@ -13,23 +13,22 @@ use crate::{milestone::MilestoneIndex, protocol::Protocol, tangle::tangle};
 
 use bee_common::worker::Error as WorkerError;
 
-use futures::{
-    channel::{mpsc, oneshot},
-    future::FutureExt,
-    select,
-    stream::StreamExt,
-};
+use futures::channel::mpsc;
 use log::info;
 
 const MILESTONE_REQUEST_RANGE: u8 = 50;
 
-pub(crate) struct MilestoneSolidifierWorkerEvent();
+type Receiver = crate::worker::Receiver<mpsc::Receiver<MilestoneSolidifierWorkerEvent>>;
 
-pub(crate) struct MilestoneSolidifierWorker {}
+pub(crate) struct MilestoneSolidifierWorkerEvent;
+
+pub(crate) struct MilestoneSolidifierWorker {
+    receiver: Receiver,
+}
 
 impl MilestoneSolidifierWorker {
-    pub(crate) fn new() -> Self {
-        Self {}
+    pub(crate) fn new(receiver: Receiver) -> Self {
+        Self { receiver }
     }
 
     // async fn solidify(&self, hash: Hash, target_index: u32) -> bool {
@@ -114,31 +113,17 @@ impl MilestoneSolidifierWorker {
         }
     }
 
-    pub(crate) async fn run(
-        self,
-        receiver: mpsc::Receiver<MilestoneSolidifierWorkerEvent>,
-        shutdown: oneshot::Receiver<()>,
-    ) -> Result<(), WorkerError> {
+    pub(crate) async fn run(mut self) -> Result<(), WorkerError> {
         info!("Running.");
 
-        let mut receiver_fused = receiver.fuse();
-        let mut shutdown_fused = shutdown.fuse();
-
-        loop {
-            select! {
-                _ = shutdown_fused => break,
-                event = receiver_fused.next() => {
-                    if let Some(MilestoneSolidifierWorkerEvent()) = event {
-                        self.request_milestones();
-                        self.solidify_milestone().await;
-                        // while tangle().get_last_solid_milestone_index() < tangle().get_last_milestone_index() {
-                        //     if !self.process_target(*tangle().get_last_solid_milestone_index() + 1).await {
-                        //         break;
-                        //     }
-                        // }
-                    }
-                }
-            }
+        while let Some(MilestoneSolidifierWorkerEvent) = self.receiver.receive_event().await {
+            self.request_milestones();
+            self.solidify_milestone().await;
+            // while tangle().get_last_solid_milestone_index() < tangle().get_last_milestone_index() {
+            //     if !self.process_target(*tangle().get_last_solid_milestone_index() + 1).await {
+            //         break;
+            //     }
+            // }
         }
 
         info!("Stopped.");


### PR DESCRIPTION
This PR introduces a new `Receiver` struct for the workers inside `bee-protocol` to deduplicate the code selecting between the shutdown future and the receiver inside the `run` method of each worker.