### PR TITLE
Track the largest solidified MilestoneIndex the node has seen

### DIFF
--- a/bee-common-ext/src/lib.rs
+++ b/bee-common-ext/src/lib.rs
@@ -12,5 +12,5 @@
 //! A crate that provides common functionalities shared across multiple crates within the Bee framework, and for
 //! applications built on-top.
 
-pub mod wait_priority_queue;
 pub mod event;
+pub mod wait_priority_queue;

--- a/bee-protocol/src/protocol/helpers.rs
+++ b/bee-protocol/src/protocol/helpers.rs
@@ -113,7 +113,7 @@ impl Protocol {
             .milestone_solidifier_worker
             // TODO try to avoid clone
             .clone()
-            .send(MilestoneSolidifierWorkerEvent())
+            .send(MilestoneSolidifierWorkerEvent::Solidify)
             .await
         {
             warn!("Triggering milestone solidification failed: {}.", e);

--- a/bee-protocol/src/protocol/protocol.rs
+++ b/bee-protocol/src/protocol/protocol.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 
 use bee_common::shutdown::Shutdown;
-use bee_common_ext::{wait_priority_queue::WaitPriorityQueue, event::Bus};
+use bee_common_ext::{event::Bus, wait_priority_queue::WaitPriorityQueue};
 use bee_crypto::ternary::{
     sponge::{CurlP27, CurlP81, Kerl, SpongeKind},
     Hash,

--- a/bee-protocol/src/worker/peer/message_handler.rs
+++ b/bee-protocol/src/worker/peer/message_handler.rs
@@ -68,7 +68,10 @@ impl MessageHandler {
                 // Read a header.
                 ReadState::Header => {
                     // We need `HEADER_SIZE` bytes to read a header.
-                    let bytes = self.events.fetch_bytes_or_shutdown(&mut self.shutdown, HEADER_SIZE).await?;
+                    let bytes = self
+                        .events
+                        .fetch_bytes_or_shutdown(&mut self.shutdown, HEADER_SIZE)
+                        .await?;
                     debug!("[{}] Reading Header...", self.address);
                     let header = Header::from_bytes(bytes);
                     // Now we are ready to read a payload.
@@ -77,8 +80,10 @@ impl MessageHandler {
                 // Read a payload.
                 ReadState::Payload(header) => {
                     // We read the quantity of bytes stated by the header.
-                    let bytes =
-                        self.events.fetch_bytes_or_shutdown(&mut self.shutdown, header.message_length.into()).await?;
+                    let bytes = self
+                        .events
+                        .fetch_bytes_or_shutdown(&mut self.shutdown, header.message_length.into())
+                        .await?;
                     // FIXME: Avoid this clone
                     let header = header.clone();
                     // Now we are ready to read the next message's header.
@@ -172,7 +177,8 @@ mod tests {
 
     use futures::{
         channel::{mpsc, oneshot},
-        {future::FutureExt, stream::StreamExt},
+        future::FutureExt,
+        stream::StreamExt,
     };
 
     use async_std::task;

--- a/bee-protocol/src/worker/peer/mod.rs
+++ b/bee-protocol/src/worker/peer/mod.rs
@@ -10,9 +10,9 @@
 // See the License for the specific language governing permissions and limitations under the License.
 
 mod handshaker;
-mod peer;
 mod message_handler;
+mod peer;
 
 pub(crate) use handshaker::PeerHandshakerWorker;
-pub(crate) use peer::PeerWorker;
 use message_handler::MessageHandler;
+pub(crate) use peer::PeerWorker;

--- a/bee-protocol/src/worker/peer/peer.rs
+++ b/bee-protocol/src/worker/peer/peer.rs
@@ -17,7 +17,8 @@ use crate::{
     peer::HandshakedPeer,
     protocol::Protocol,
     worker::{
-        peer::MessageHandler, MilestoneResponderWorkerEvent, TransactionResponderWorkerEvent, TransactionWorkerEvent,
+        peer::MessageHandler, MilestoneResponderWorkerEvent, MilestoneSolidifierWorkerEvent,
+        TransactionResponderWorkerEvent, TransactionWorkerEvent,
     },
 };
 
@@ -144,6 +145,11 @@ impl PeerWorker {
 
                         self.peer.metrics.heartbeat_received_inc();
                         Protocol::get().metrics.heartbeat_received_inc();
+                        Protocol::get()
+                            .milestone_solidifier_worker
+                            .clone()
+                            .send(MilestoneSolidifierWorkerEvent::NewIndex(message.solid_milestone_index))
+                            .await;
                     }
                     Err(e) => {
                         warn!("[{}] Reading Heartbeat failed: {:?}.", self.peer.address, e);


### PR DESCRIPTION
This PR aims to avoid requesting non-existent milestones by using the index of the last solid milestone inside the `Heartbeat` message received from other nodes.