### PR TITLE
use new ShutdownStream

### DIFF
--- a/bee-protocol/src/worker/broadcaster.rs
+++ b/bee-protocol/src/worker/broadcaster.rs
@@ -14,14 +14,14 @@ use crate::{
     protocol::Protocol,
 };
 
-use bee_common::worker::Error as WorkerError;
+use bee_common::{shutdown_stream::ShutdownStream, worker::Error as WorkerError};
 use bee_network::{Command::SendMessage, EndpointId, Network};
 
 use futures::{channel::mpsc, stream::StreamExt};
 
 use log::{info, warn};
 
-type Receiver = crate::worker::Receiver<mpsc::Receiver<BroadcasterWorkerEvent>>;
+type Receiver = ShutdownStream<mpsc::Receiver<BroadcasterWorkerEvent>>;
 
 pub(crate) struct BroadcasterWorkerEvent {
     pub(crate) source: Option<EndpointId>,

--- a/bee-protocol/src/worker/milestone_validator.rs
+++ b/bee-protocol/src/worker/milestone_validator.rs
@@ -16,7 +16,7 @@ use crate::{
     tangle::tangle,
 };
 
-use bee_common::worker::Error as WorkerError;
+use bee_common::{shutdown_stream::ShutdownStream, worker::Error as WorkerError};
 use bee_crypto::ternary::{
     sponge::{Kerl, Sponge},
     Hash,
@@ -24,12 +24,12 @@ use bee_crypto::ternary::{
 use bee_signing::ternary::{PublicKey, RecoverableSignature};
 use bee_transaction::Vertex;
 
+use futures::{channel::mpsc, stream::StreamExt};
 use log::{debug, info};
 
-use futures::{channel::mpsc, stream::StreamExt};
 use std::marker::PhantomData;
 
-type Receiver = crate::worker::Receiver<mpsc::Receiver<MilestoneValidatorWorkerEvent>>;
+type Receiver = ShutdownStream<mpsc::Receiver<MilestoneValidatorWorkerEvent>>;
 
 #[derive(Debug)]
 pub(crate) enum MilestoneValidatorWorkerError {

--- a/bee-protocol/src/worker/mod.rs
+++ b/bee-protocol/src/worker/mod.rs
@@ -39,38 +39,3 @@ pub(crate) use solidifier::{
 pub(crate) use status::StatusWorker;
 pub(crate) use tps::TpsWorker;
 pub(crate) use transaction::{TransactionWorker, TransactionWorkerEvent};
-
-use futures::{
-    channel::oneshot,
-    future::{self, FutureExt},
-    stream::{self, Stream, StreamExt},
-    task::{Context, Poll},
-};
-
-use std::pin::Pin;
-
-pub(crate) struct Receiver<R> {
-    receiver: stream::Fuse<R>,
-    shutdown: future::Fuse<oneshot::Receiver<()>>,
-}
-
-impl<R: Stream> Receiver<R> {
-    pub(crate) fn new(receiver: R, shutdown: oneshot::Receiver<()>) -> Self {
-        Self {
-            receiver: receiver.fuse(),
-            shutdown: shutdown.fuse(),
-        }
-    }
-}
-
-impl<R: Stream<Item = E> + std::marker::Unpin, E> Stream for Receiver<R> {
-    type Item = E;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        if let Poll::Ready(_) = self.shutdown.poll_unpin(cx) {
-            Poll::Ready(None)
-        } else {
-            self.receiver.poll_next_unpin(cx)
-        }
-    }
-}

--- a/bee-protocol/src/worker/responder/milestone.rs
+++ b/bee-protocol/src/worker/responder/milestone.rs
@@ -15,7 +15,7 @@ use crate::{
     worker::SenderWorker,
 };
 
-use bee_common::worker::Error as WorkerError;
+use bee_common::{shutdown_stream::ShutdownStream, worker::Error as WorkerError};
 use bee_network::EndpointId;
 use bee_ternary::{T1B1Buf, T5B1Buf, TritBuf};
 use bee_transaction::bundled::BundledTransaction as Transaction;
@@ -25,7 +25,7 @@ use futures::{channel::mpsc, stream::StreamExt};
 
 use log::info;
 
-type Receiver = crate::worker::Receiver<mpsc::Receiver<MilestoneResponderWorkerEvent>>;
+type Receiver = ShutdownStream<mpsc::Receiver<MilestoneResponderWorkerEvent>>;
 
 pub(crate) struct MilestoneResponderWorkerEvent {
     pub(crate) epid: EndpointId,

--- a/bee-protocol/src/worker/responder/transaction.rs
+++ b/bee-protocol/src/worker/responder/transaction.rs
@@ -15,7 +15,7 @@ use crate::{
     worker::SenderWorker,
 };
 
-use bee_common::worker::Error as WorkerError;
+use bee_common::{shutdown_stream::ShutdownStream, worker::Error as WorkerError};
 use bee_crypto::ternary::Hash;
 use bee_network::EndpointId;
 use bee_ternary::{T1B1Buf, T5B1Buf, TritBuf, Trits, T5B1};
@@ -25,7 +25,7 @@ use bytemuck::cast_slice;
 use futures::{channel::mpsc, stream::StreamExt};
 use log::info;
 
-type Receiver = crate::worker::Receiver<mpsc::Receiver<TransactionResponderWorkerEvent>>;
+type Receiver = ShutdownStream<mpsc::Receiver<TransactionResponderWorkerEvent>>;
 
 pub(crate) struct TransactionResponderWorkerEvent {
     pub(crate) epid: EndpointId,

--- a/bee-protocol/src/worker/sender.rs
+++ b/bee-protocol/src/worker/sender.rs
@@ -17,15 +17,15 @@ use crate::{
     protocol::Protocol,
 };
 
+use bee_common::shutdown_stream::ShutdownStream;
 use bee_network::{Command::SendMessage, EndpointId, Network};
+
+use futures::{channel::mpsc, sink::SinkExt, stream::StreamExt};
+use log::warn;
 
 use std::sync::Arc;
 
-use futures::{channel::mpsc, sink::SinkExt, stream::StreamExt};
-
-use log::warn;
-
-type Receiver<M> = crate::worker::Receiver<mpsc::Receiver<M>>;
+type Receiver<M> = ShutdownStream<mpsc::Receiver<M>>;
 
 pub(crate) struct SenderWorker<M: Message> {
     network: Network,

--- a/bee-protocol/src/worker/solidifier/milestone.rs
+++ b/bee-protocol/src/worker/solidifier/milestone.rs
@@ -11,12 +11,12 @@
 
 use crate::{milestone::MilestoneIndex, protocol::Protocol, tangle::tangle};
 
-use bee_common::worker::Error as WorkerError;
+use bee_common::{shutdown_stream::ShutdownStream, worker::Error as WorkerError};
 
 use futures::{channel::mpsc, stream::StreamExt};
 use log::info;
 
-type Receiver = crate::worker::Receiver<mpsc::Receiver<MilestoneSolidifierWorkerEvent>>;
+type Receiver = ShutdownStream<mpsc::Receiver<MilestoneSolidifierWorkerEvent>>;
 
 pub(crate) struct MilestoneSolidifierWorkerEvent;
 

--- a/bee-protocol/src/worker/solidifier/transaction.rs
+++ b/bee-protocol/src/worker/solidifier/transaction.rs
@@ -11,16 +11,16 @@
 
 use crate::{milestone::MilestoneIndex, protocol::Protocol, tangle::tangle};
 
-use bee_common::worker::Error as WorkerError;
+use bee_common::{shutdown_stream::ShutdownStream, worker::Error as WorkerError};
 use bee_crypto::ternary::Hash;
 use bee_tangle::traversal;
-
-use std::collections::HashSet;
 
 use futures::{channel::mpsc, stream::StreamExt};
 use log::info;
 
-type Receiver = crate::worker::Receiver<mpsc::Receiver<TransactionSolidifierWorkerEvent>>;
+use std::collections::HashSet;
+
+type Receiver = ShutdownStream<mpsc::Receiver<TransactionSolidifierWorkerEvent>>;
 
 pub(crate) struct TransactionSolidifierWorkerEvent(pub(crate) Hash, pub(crate) MilestoneIndex);
 


### PR DESCRIPTION
This PR updates `bee-p` to use the new `ShutdownStream` introduced in https://github.com/iotaledger/bee/pull/116.