### PR TITLE
Adjust iterator status check in Exist storage op

### DIFF
--- a/bee-storage/bee-storage-rocksdb/src/access/exist.rs
+++ b/bee-storage/bee-storage-rocksdb/src/access/exist.rs
@@ -46,9 +46,9 @@ impl Exist<HashedIndex<Blake2b>, Vec<MessageId>> for Storage {
         let payload_index_to_message_id = self.inner.cf_handle(PAYLOAD_INDEX_TO_MESSAGE_ID).unwrap();
 
         let mut iterator = self.inner.prefix_iterator_cf(&payload_index_to_message_id, index);
-
+        let exist = iterator.next().is_some();
         match iterator.status() {
-            Ok(_) => Ok(iterator.next().is_some()),
+            Ok(_) => Ok(exist),
             Err(e) => Err(e)?,
         }
     }


### PR DESCRIPTION
Do `iterator.status()` check after `iterator.next().is_some()`