### PR TITLE
feat(message) derive Eq and PartialEq on the Payload enum

### DIFF
--- a/bee-message/src/payload/indexation.rs
+++ b/bee-message/src/payload/indexation.rs
@@ -23,7 +23,7 @@ use core::convert::TryInto;
 
 pub const HASHED_INDEX_SIZE: usize = 32;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Indexation {
     index: String,
     data: Box<[u8]>,

--- a/bee-message/src/payload/milestone.rs
+++ b/bee-message/src/payload/milestone.rs
@@ -21,7 +21,7 @@ pub const MILESTONE_MERKLE_PROOF_LENGTH: usize = 64;
 pub const MILESTONE_PUBLIC_KEY_LENGTH: usize = 32;
 pub const MILESTONE_SIGNATURE_LENGTH: usize = 64;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Milestone {
     essence: MilestoneEssence,
     // TODO length is 64, change to array when std::array::LengthAtMost32 disappears.
@@ -78,7 +78,7 @@ impl Packable for Milestone {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct MilestoneEssence {
     index: u32,
     timestamp: u64,

--- a/bee-message/src/payload/mod.rs
+++ b/bee-message/src/payload/mod.rs
@@ -30,7 +30,7 @@ const PAYLOAD_MILESTONE_TYPE: u32 = 1;
 const PAYLOAD_INDEXATION_TYPE: u32 = 2;
 
 #[non_exhaustive]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Payload {
     Transaction(Box<Transaction>),
     Milestone(Box<Milestone>),

--- a/bee-message/src/payload/transaction/essence.rs
+++ b/bee-message/src/payload/transaction/essence.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 
 use alloc::{boxed::Box, vec::Vec};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 pub struct TransactionEssence {
     inputs: Box<[Input]>,
     outputs: Box<[Output]>,

--- a/bee-message/src/payload/transaction/essence.rs
+++ b/bee-message/src/payload/transaction/essence.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 
 use alloc::{boxed::Box, vec::Vec};
 
-#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct TransactionEssence {
     inputs: Box<[Input]>,
     outputs: Box<[Output]>,

--- a/bee-message/src/payload/transaction/mod.rs
+++ b/bee-message/src/payload/transaction/mod.rs
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 use alloc::{boxed::Box, vec::Vec};
 use core::{cmp::Ordering, slice::Iter};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Transaction {
     essence: TransactionEssence,
     unlock_blocks: Box<[UnlockBlock]>,


### PR DESCRIPTION
The Eq and PartialEq impl are needed because we need to compare Payloads when checking against reattachments (a message A is a reattachment of B if A's payload equals B's payload).