### PR TITLE
feat(message) `serde` using with ToStr/Display, enums adjacently tagged

### DIFF
--- a/bee-message/src/lib.rs
+++ b/bee-message/src/lib.rs
@@ -14,6 +14,8 @@
 #[macro_use]
 extern crate alloc;
 
+#[macro_use]
+mod serde;
 mod error;
 mod message;
 mod message_id;

--- a/bee-message/src/message_id.rs
+++ b/bee-message/src/message_id.rs
@@ -13,14 +13,14 @@ use crate::Error;
 
 use bee_common::packable::{Packable, Read, Write};
 
-use serde::{Deserialize, Serialize};
-
 use core::{convert::TryInto, str::FromStr};
 
 pub const MESSAGE_ID_LENGTH: usize = 32;
 
-#[derive(Clone, Copy, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub struct MessageId([u8; MESSAGE_ID_LENGTH]);
+
+string_serde_impl!(MessageId);
 
 impl From<[u8; MESSAGE_ID_LENGTH]> for MessageId {
     fn from(bytes: [u8; MESSAGE_ID_LENGTH]) -> Self {

--- a/bee-message/src/payload/transaction/input/mod.rs
+++ b/bee-message/src/payload/transaction/input/mod.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 
 #[non_exhaustive]
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, Hash, Ord, PartialOrd)]
+#[serde(tag = "type", content = "data")]
 pub enum Input {
     UTXO(UTXOInput),
 }

--- a/bee-message/src/payload/transaction/input/utxo.rs
+++ b/bee-message/src/payload/transaction/input/utxo.rs
@@ -16,12 +16,12 @@ use crate::{
 
 use bee_common::packable::{Packable, Read, Write};
 
-use serde::{Deserialize, Serialize};
-
 use core::{convert::From, str::FromStr};
 
-#[derive(Clone, Eq, PartialEq, Deserialize, Serialize, Hash, Ord, PartialOrd)]
+#[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct UTXOInput(OutputId);
+
+string_serde_impl!(UTXOInput);
 
 impl From<OutputId> for UTXOInput {
     fn from(id: OutputId) -> Self {

--- a/bee-message/src/payload/transaction/output/address/ed25519.rs
+++ b/bee-message/src/payload/transaction/output/address/ed25519.rs
@@ -14,15 +14,16 @@ use crate::Error;
 use bee_common::packable::{Packable, Read, Write};
 
 use bech32::{self, ToBase32};
-use serde::{Deserialize, Serialize};
 
 use alloc::{string::String, vec};
 use core::{convert::TryInto, str::FromStr};
 
 pub const ED25519_ADDRESS_LENGTH: usize = 32;
 
-#[derive(Clone, Eq, PartialEq, Deserialize, Serialize, Ord, PartialOrd)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Ed25519Address([u8; ED25519_ADDRESS_LENGTH]);
+
+string_serde_impl!(Ed25519Address);
 
 impl From<[u8; ED25519_ADDRESS_LENGTH]> for Ed25519Address {
     fn from(bytes: [u8; ED25519_ADDRESS_LENGTH]) -> Self {

--- a/bee-message/src/payload/transaction/output/address/mod.rs
+++ b/bee-message/src/payload/transaction/output/address/mod.rs
@@ -25,6 +25,7 @@ use alloc::string::String;
 
 #[non_exhaustive]
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, Ord, PartialOrd)]
+#[serde(tag = "type", content = "data")]
 pub enum Address {
     Wots(WotsAddress),
     Ed25519(Ed25519Address),

--- a/bee-message/src/payload/transaction/output/mod.rs
+++ b/bee-message/src/payload/transaction/output/mod.rs
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize};
 
 #[non_exhaustive]
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, Ord, PartialOrd)]
+#[serde(tag = "type", content = "data")]
 pub enum Output {
     SignatureLockedSingle(SignatureLockedSingleOutput),
 }

--- a/bee-message/src/payload/transaction/output/output_id.rs
+++ b/bee-message/src/payload/transaction/output/output_id.rs
@@ -16,8 +16,6 @@ use crate::{
 
 use bee_common::packable::{Packable, Read, Write};
 
-use serde::{Deserialize, Serialize};
-
 use core::{
     convert::{From, TryInto},
     str::FromStr,
@@ -25,11 +23,13 @@ use core::{
 
 pub const OUTPUT_ID_LENGTH: usize = TRANSACTION_ID_LENGTH + std::mem::size_of::<u16>();
 
-#[derive(Clone, Copy, Eq, PartialEq, Deserialize, Serialize, Hash, Ord, PartialOrd)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct OutputId {
     transaction_id: TransactionId,
     index: u16,
 }
+
+string_serde_impl!(OutputId);
 
 impl From<[u8; OUTPUT_ID_LENGTH]> for OutputId {
     fn from(bytes: [u8; OUTPUT_ID_LENGTH]) -> Self {

--- a/bee-message/src/payload/transaction/unlock/mod.rs
+++ b/bee-message/src/payload/transaction/unlock/mod.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 
 #[non_exhaustive]
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "type", content = "data")]
 pub enum UnlockBlock {
     Signature(SignatureUnlock),
     Reference(ReferenceUnlock),

--- a/bee-message/src/payload/transaction/unlock/signature/mod.rs
+++ b/bee-message/src/payload/transaction/unlock/signature/mod.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 
 #[non_exhaustive]
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "type", content = "data")]
 pub enum SignatureUnlock {
     Wots(WotsSignature),
     Ed25519(Ed25519Signature),

--- a/bee-message/src/serde.rs
+++ b/bee-message/src/serde.rs
@@ -1,0 +1,35 @@
+#[macro_export]
+macro_rules! string_serde_impl {
+  ($type:ty) => {
+    use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+    impl Serialize for $type {
+      fn serialize<S: Serializer>(&self, s: S) -> std::result::Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_string())
+      }
+    }
+
+    impl<'de> Deserialize<'de> for $type {
+      fn deserialize<D>(deserializer: D) -> Result<$type, D::Error>
+      where
+        D: Deserializer<'de>,
+      {
+        struct StringVisitor;
+        impl<'de> Visitor<'de> for StringVisitor {
+          type Value = $type;
+          fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("a string representing the value")
+          }
+
+          fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+          where
+            E: serde::de::Error,
+          {
+            let value = <$type>::from_str(v).map_err(|e| serde::de::Error::custom(e))?;
+            Ok(value)
+          }
+        }
+        deserializer.deserialize_str(StringVisitor)
+      }
+    }
+  };
+}


### PR DESCRIPTION
Using the `FromStr`/`Display` traits to deserialize/serialize types simplifies the bee-message crate usage on FFI bindings, since we often have to serialize the Message types to JavaScript/Python/Go.. and deserialize the types back on the Rust side. (e.g. serialize a `Message` to JS and take a `MessageId` as string later).